### PR TITLE
Feature 4/sociallogin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.1.Final'
 
-    implementation group: 'org.springframework.data', name: 'spring-data-mongodb', version: '3.2.2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     implementation 'com.auth0:java-jwt:3.4.1'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.1.Final'
 
     implementation group: 'org.springframework.data', name: 'spring-data-mongodb', version: '3.2.2'
+    implementation 'com.auth0:java-jwt:3.4.1'
 }
 
 test {

--- a/src/main/java/com/meme/ala/common/message/ResponseMessage.java
+++ b/src/main/java/com/meme/ala/common/message/ResponseMessage.java
@@ -4,5 +4,5 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 public class ResponseMessage {
-    public static final String EXAMPLE = "메시지 예시입니다.";
+    public static final String SUCCESS = "success";
 }

--- a/src/main/java/com/meme/ala/core/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/meme/ala/core/auth/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.meme.ala.core.auth;
+package com.meme.ala.core.auth.jwt;
 
 public class JwtAuthenticationFilter {
 }

--- a/src/main/java/com/meme/ala/core/auth/oauth/GoogleUser.java
+++ b/src/main/java/com/meme/ala/core/auth/oauth/GoogleUser.java
@@ -31,6 +31,7 @@ public class GoogleUser implements OAuthUserInfo{
 
     @Override
     public String getImgUrl() {
-        return (String)attribute.get("imageUrl");
+        //TODO: 2021.7.15. DEFAULT 이미지(코알라) 세팅
+        return null;
     }
 }

--- a/src/main/java/com/meme/ala/core/auth/oauth/GoogleUser.java
+++ b/src/main/java/com/meme/ala/core/auth/oauth/GoogleUser.java
@@ -1,0 +1,31 @@
+package com.meme.ala.core.auth.oauth;
+
+import java.util.Map;
+
+public class GoogleUser implements OAuthUserInfo{
+    private Map<String, Object> attribute;
+
+    public GoogleUser(Map<String, Object> attribute) {
+        this.attribute = attribute;
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String)attribute.get("googleId");
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getEmail() {
+        return (String)attribute.get("email");
+    }
+
+    @Override
+    public String getName() {
+        return (String)attribute.get("name");
+    }
+}

--- a/src/main/java/com/meme/ala/core/auth/oauth/GoogleUser.java
+++ b/src/main/java/com/meme/ala/core/auth/oauth/GoogleUser.java
@@ -28,4 +28,9 @@ public class GoogleUser implements OAuthUserInfo{
     public String getName() {
         return (String)attribute.get("name");
     }
+
+    @Override
+    public String getImgUrl() {
+        return (String)attribute.get("imageUrl");
+    }
 }

--- a/src/main/java/com/meme/ala/core/auth/oauth/OAuthUserInfo.java
+++ b/src/main/java/com/meme/ala/core/auth/oauth/OAuthUserInfo.java
@@ -1,0 +1,8 @@
+package com.meme.ala.core.auth.oauth;
+
+public interface OAuthUserInfo {
+    String getProviderId();
+    String getProvider();
+    String getEmail();
+    String getName();
+}

--- a/src/main/java/com/meme/ala/core/auth/oauth/OAuthUserInfo.java
+++ b/src/main/java/com/meme/ala/core/auth/oauth/OAuthUserInfo.java
@@ -5,4 +5,5 @@ public interface OAuthUserInfo {
     String getProvider();
     String getEmail();
     String getName();
+    String getImgUrl();
 }

--- a/src/main/java/com/meme/ala/domain/member/controller/MemberController.java
+++ b/src/main/java/com/meme/ala/domain/member/controller/MemberController.java
@@ -1,0 +1,43 @@
+package com.meme.ala.domain.member.controller;
+
+import com.meme.ala.common.dto.ResponseDto;
+import com.meme.ala.core.auth.oauth.GoogleUser;
+import com.meme.ala.core.auth.oauth.OAuthUserInfo;
+import com.meme.ala.core.error.ErrorCode;
+import com.meme.ala.core.error.exception.EntityNotFoundException;
+import com.meme.ala.domain.member.model.entity.Member;
+import com.meme.ala.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberRepository memberRepository;
+
+    // TODO: 2021.7.15. 성공 시 JWT 토큰 생성 및 반환하는 기능 추가 - jongmin
+    @PostMapping("/oauth/jwt/google")
+    public ResponseEntity<ResponseDto<String>> jwtCreate(@RequestBody Map<String, Object> data) {
+        OAuthUserInfo googleUser =
+                new GoogleUser((Map<String, Object>)data.get("profileObj"));
+        Optional<Member> optionalMember =
+                memberRepository.findByEmail(googleUser.getEmail());
+        if(optionalMember.isPresent()){
+            return new ResponseEntity<ResponseDto<String>>(
+                    new ResponseDto<String>(HttpStatus.OK.value(),"success","auth success")
+                    ,HttpStatus.OK);
+        }
+        else {
+            return new ResponseEntity<ResponseDto<String>>(
+                    new ResponseDto<String>(HttpStatus.NOT_FOUND.value(),"not found",null)
+                    ,HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/meme/ala/domain/member/controller/MemberController.java
+++ b/src/main/java/com/meme/ala/domain/member/controller/MemberController.java
@@ -1,12 +1,7 @@
 package com.meme.ala.domain.member.controller;
 
 import com.meme.ala.common.dto.ResponseDto;
-import com.meme.ala.core.auth.oauth.GoogleUser;
-import com.meme.ala.core.auth.oauth.OAuthUserInfo;
-import com.meme.ala.core.error.ErrorCode;
-import com.meme.ala.core.error.exception.EntityNotFoundException;
-import com.meme.ala.domain.member.model.entity.Member;
-import com.meme.ala.domain.member.repository.MemberRepository;
+import com.meme.ala.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,29 +10,18 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
-import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     // TODO: 2021.7.15. 성공 시 JWT 토큰 생성 및 반환하는 기능 추가 - jongmin
-    @PostMapping("/oauth/jwt/google")
+    @PostMapping("api/v1/oauth/jwt/google")
     public ResponseEntity<ResponseDto<String>> jwtCreate(@RequestBody Map<String, Object> data) {
-        OAuthUserInfo googleUser =
-                new GoogleUser((Map<String, Object>)data.get("profileObj"));
-        Optional<Member> optionalMember =
-                memberRepository.findByEmail(googleUser.getEmail());
-        if(optionalMember.isPresent()){
-            return new ResponseEntity<ResponseDto<String>>(
-                    new ResponseDto<String>(HttpStatus.OK.value(),"success","auth success")
-                    ,HttpStatus.OK);
-        }
-        else {
-            return new ResponseEntity<ResponseDto<String>>(
-                    new ResponseDto<String>(HttpStatus.NOT_FOUND.value(),"not found",null)
-                    ,HttpStatus.NOT_FOUND);
-        }
+        String jwtToken = memberService.loginOrJoin(data);
+        return new ResponseEntity<ResponseDto<String>>(
+                new ResponseDto<String>(HttpStatus.OK.value(), "success", jwtToken)
+                , HttpStatus.OK);
     }
 }

--- a/src/main/java/com/meme/ala/domain/member/controller/MemberController.java
+++ b/src/main/java/com/meme/ala/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.meme.ala.domain.member.controller;
 
 import com.meme.ala.common.dto.ResponseDto;
+import com.meme.ala.common.message.ResponseMessage;
 import com.meme.ala.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,7 +22,7 @@ public class MemberController {
     public ResponseEntity<ResponseDto<String>> jwtCreate(@RequestBody Map<String, Object> data) {
         String jwtToken = memberService.loginOrJoin(data);
         return new ResponseEntity<ResponseDto<String>>(
-                new ResponseDto<String>(HttpStatus.OK.value(), "success", jwtToken)
+                new ResponseDto<String>(HttpStatus.OK.value(), ResponseMessage.SUCCESS, jwtToken)
                 , HttpStatus.OK);
     }
 }

--- a/src/main/java/com/meme/ala/domain/member/model/entity/Member.java
+++ b/src/main/java/com/meme/ala/domain/member/model/entity/Member.java
@@ -1,11 +1,14 @@
 package com.meme.ala.domain.member.model.entity;
 
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
+@NoArgsConstructor
 @Document(collection = "member")
 public class Member{
     @Id
@@ -15,4 +18,13 @@ public class Member{
     private String imgUrl;
     private String googleId;
     private String naverId;
+
+    @Builder
+    public Member(String name, String email, String imgUrl, String googleId, String naverId){
+        this.name=name;
+        this.email=email;
+        this.imgUrl=imgUrl;
+        this.googleId=googleId;
+        this.naverId=naverId;
+    }
 }

--- a/src/main/java/com/meme/ala/domain/member/model/entity/Member.java
+++ b/src/main/java/com/meme/ala/domain/member/model/entity/Member.java
@@ -1,4 +1,18 @@
 package com.meme.ala.domain.member.model.entity;
 
-public class Member {
+import lombok.Getter;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Document(collection = "member")
+public class Member{
+    @Id
+    private ObjectId id;
+    private String name;
+    private String email;
+    private String imgUrl;
+    private String googleId;
+    private String naverId;
 }

--- a/src/main/java/com/meme/ala/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/meme/ala/domain/member/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.meme.ala.domain.member.repository;
+
+import com.meme.ala.domain.member.model.entity.Member;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends MongoRepository<Member, ObjectId> {
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/meme/ala/domain/member/service/MemberService.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberService.java
@@ -1,0 +1,7 @@
+package com.meme.ala.domain.member.service;
+
+import java.util.Map;
+
+public interface MemberService {
+    public String loginOrJoin(Map<String, Object> data);
+}

--- a/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
@@ -1,0 +1,42 @@
+package com.meme.ala.domain.member.service;
+
+import com.meme.ala.core.auth.oauth.GoogleUser;
+import com.meme.ala.core.auth.oauth.OAuthUserInfo;
+import com.meme.ala.domain.member.model.entity.Member;
+import com.meme.ala.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class MemberServiceImpl implements MemberService{
+    @Autowired
+    private final MemberRepository memberRepository;
+
+    @Override
+    public String loginOrJoin(Map<String, Object> data) {
+        OAuthUserInfo googleUser =
+                new GoogleUser((Map<String, Object>)data.get("profileObj"));
+        Optional<Member> optionalMember =
+                memberRepository.findByEmail(googleUser.getEmail());
+        if(optionalMember.isPresent()){
+            // TODO: 2021.7.15. 성공 시 JWT 토큰 생성 및 반환하는 기능 추가 - jongmin
+            return "dummy token";
+        }
+        else {
+            Member newMember=Member.builder()
+                    .email(googleUser.getEmail())
+                    .name(googleUser.getName())
+                    .googleId(googleUser.getProviderId())
+                    .imgUrl(googleUser.getImgUrl())
+                    .build();
+            memberRepository.save(newMember);
+            // TODO: 2021.7.15. 성공 시 JWT 토큰 생성 및 반환하는 기능 추가 - jongmin
+            return "dummy token";
+        }
+    }
+}

--- a/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
@@ -32,7 +32,7 @@ public class MemberServiceImpl implements MemberService{
                     .email(googleUser.getEmail())
                     .name(googleUser.getName())
                     .googleId(googleUser.getProviderId())
-                    .imgUrl(googleUser.getImgUrl())
+                    .imgUrl(null) // TODO: 2021.7.15. DEFAULT 이미지 Assign
                     .build();
             memberRepository.save(newMember);
             // TODO: 2021.7.15. 성공 시 JWT 토큰 생성 및 반환하는 기능 추가 - jongmin

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.data.mongodb.uri=mongodb://localhost:27017
+spring.data.mongodb.database=testdb

--- a/src/test/java/com/meme/ala/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/meme/ala/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,65 @@
+package com.meme.ala.domain.member.controller;
+
+import com.meme.ala.domain.member.model.entity.Member;
+import com.meme.ala.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class MemberControllerTest {
+    @LocalServerPort
+    private int port;
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member memberSetup(){
+        return memberRepository.save(Member.builder()
+                .name("Jongmin Jung")
+                .email("test@gmail.com")
+                .imgUrl("https://user-images.githubusercontent.com/46064193/125324764-2bc8e200-e37b-11eb-8d07-9ac29d0d1b1a.png")
+                .googleId("1155")
+                .build());
+    }
+
+    @AfterEach
+    private void deleteAll(){
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    public void 구글_OAuth_로그인() throws Exception{
+        memberSetup();
+        String sampleRequestBody=
+                "{\n" +
+                        "  \"profileObj\": {\n" +
+                        "    \"googleId\": \"1155\",\n" +
+                        "    \"imageUrl\": \"https://user-images.githubusercontent.com/46064193/125324764-2bc8e200-e37b-11eb-8d07-9ac29d0d1b1a.png\",\n" +
+                        "    \"email\": \"test@gmail.com\",\n" +
+                        "    \"name\": \"Jongmin Jung\",\n" +
+                        "    \"givenName\": \"Jongmin\",\n" +
+                        "    \"familyName\": \"Jung\"\n" +
+                        "  }\n" +
+                        "}";
+        String url="http://localhost:"+port+"/api/v1/oauth/jwt/google";
+        mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(sampleRequestBody))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data").value("dummy token"));
+    }
+}


### PR DESCRIPTION
-소셜 로그인 Google OAuth 기능 및 테스트 코드 완성
-MemberService.java: 회원 DB에 있을 경우 jwt 토큰 제공, 없을 경우 DB에 저장 후 jwt 토큰 제공
-OAuthUserInfo 인터페이스를 통해 다른 Provider(Naver, Kakao, Facebook)들과 통일된 기능 제공 가능

//TODO
- Naver 등 다른 Provider의 OAuth 기능
- 현재는 "dummy token"으로 jwt 토큰을 제공하니 향후 다른 Feature branch에서 jwt.create로 jwt 기능 추가