### PR TITLE
Feature 69/init friend info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
     implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     compile group: 'com.github.ben-manes.caffeine', name: 'caffeine'
+
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: '2.5.3'
 }
 
 

--- a/src/main/java/com/meme/ala/AlaApplication.java
+++ b/src/main/java/com/meme/ala/AlaApplication.java
@@ -3,7 +3,11 @@ package com.meme.ala;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+@EnableAsync
 @EnableCaching
 @SpringBootApplication
 public class AlaApplication {

--- a/src/main/java/com/meme/ala/core/annotation/PublishEvent.java
+++ b/src/main/java/com/meme/ala/core/annotation/PublishEvent.java
@@ -1,0 +1,12 @@
+package com.meme.ala.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PublishEvent {
+    String value() default "";
+}

--- a/src/main/java/com/meme/ala/core/aop/PublishEventAspect.java
+++ b/src/main/java/com/meme/ala/core/aop/PublishEventAspect.java
@@ -1,0 +1,37 @@
+package com.meme.ala.core.aop;
+
+import com.meme.ala.domain.event.model.entity.InitEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Aspect
+public class PublishEventAspect implements ApplicationEventPublisherAware {
+    private ApplicationEventPublisher eventPublisher;
+
+    @Pointcut("@annotation(com.meme.ala.core.annotation.PublishEvent)")
+    public void eventPointcut() {
+    }
+
+    @AfterReturning(pointcut = "eventPointcut()", returning = "returnObj")
+    public void afterReturning(JoinPoint joinPoint, Object returnObj){
+        String method = joinPoint.getSignature().getName();
+        log.info(method + "가 실행됩니다.");
+        if(method.equals("join")){
+            InitEvent event = new InitEvent((String) returnObj);
+            eventPublisher.publishEvent(event);
+        }
+    }
+
+    @Override
+    public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.eventPublisher = applicationEventPublisher;
+    }
+}

--- a/src/main/java/com/meme/ala/domain/event/component/EventHandler.java
+++ b/src/main/java/com/meme/ala/domain/event/component/EventHandler.java
@@ -1,0 +1,29 @@
+package com.meme.ala.domain.event.component;
+
+import com.meme.ala.core.error.ErrorCode;
+import com.meme.ala.core.error.exception.EntityNotFoundException;
+import com.meme.ala.domain.friend.service.FriendService;
+import com.meme.ala.domain.member.model.entity.Member;
+import com.meme.ala.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class EventHandler {
+
+    private final FriendService friendService;
+    private final MemberRepository memberRepository;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void initMember(String email){
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        friendService.initFriendInfo(member);
+    }
+}

--- a/src/main/java/com/meme/ala/domain/event/component/EventHandler.java
+++ b/src/main/java/com/meme/ala/domain/event/component/EventHandler.java
@@ -2,6 +2,7 @@ package com.meme.ala.domain.event.component;
 
 import com.meme.ala.core.error.ErrorCode;
 import com.meme.ala.core.error.exception.EntityNotFoundException;
+import com.meme.ala.domain.event.model.entity.InitEvent;
 import com.meme.ala.domain.friend.service.FriendService;
 import com.meme.ala.domain.member.model.entity.Member;
 import com.meme.ala.domain.member.repository.MemberRepository;
@@ -20,8 +21,8 @@ public class EventHandler {
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void initMember(String email){
-        Member member = memberRepository.findByEmail(email)
+    public void initMember(InitEvent event){
+        Member member = memberRepository.findByEmail(event.getEmail())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
 
         friendService.initFriendInfo(member);

--- a/src/main/java/com/meme/ala/domain/event/model/entity/InitEvent.java
+++ b/src/main/java/com/meme/ala/domain/event/model/entity/InitEvent.java
@@ -1,0 +1,10 @@
+package com.meme.ala.domain.event.model.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class InitEvent {
+    private String email;
+}

--- a/src/main/java/com/meme/ala/domain/friend/model/entity/InitFriendEvent.java
+++ b/src/main/java/com/meme/ala/domain/friend/model/entity/InitFriendEvent.java
@@ -1,7 +1,0 @@
-package com.meme.ala.domain.friend.model.entity;
-
-import org.springframework.context.ApplicationEvent;
-
-public class InitFriendEvent {
-
-}

--- a/src/main/java/com/meme/ala/domain/friend/model/entity/InitFriendEvent.java
+++ b/src/main/java/com/meme/ala/domain/friend/model/entity/InitFriendEvent.java
@@ -1,0 +1,7 @@
+package com.meme.ala.domain.friend.model.entity;
+
+import org.springframework.context.ApplicationEvent;
+
+public class InitFriendEvent {
+
+}

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendService.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendService.java
@@ -9,4 +9,5 @@ public interface FriendService {
     void addMemberFriend(Member member, String followingNickname);
     void acceptMemberFriend(Member member, String followerNickname);
     void deleteMemberFriend(Member member, String friendNickname);
+    void initFriendInfo(Member member);
 }

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendServiceImpl.java
@@ -100,6 +100,14 @@ public class FriendServiceImpl implements FriendService {
         friendInfoRepository.saveAll(Arrays.asList(memberFriendInfo, friendFriendInfo));
     }
 
+    @Override
+    @Transactional
+    public void initFriendInfo(Member member){
+        FriendInfo friendInfo = FriendInfo.builder().memberId(member.getId()).build();
+
+        friendInfoRepository.save(friendInfo);
+    }
+
     private boolean isFriend(Member member, Member friend){
         FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
                     .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));

--- a/src/main/java/com/meme/ala/domain/member/service/MemberService.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberService.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface MemberService {
     Map<String, String> loginOrJoin(Map<String, Object> data, String provider);
 
-    void join(OAuthUserInfo authUserInfo, String provider);
+    String join(OAuthUserInfo authUserInfo, String provider);
 
     void updateMember(Member newMember, MemberPrincipalDto memberPrincipalDto);
 

--- a/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
@@ -1,6 +1,7 @@
 package com.meme.ala.domain.member.service;
 
 import com.meme.ala.common.message.ResponseMessage;
+import com.meme.ala.core.annotation.PublishEvent;
 import com.meme.ala.core.auth.jwt.JwtProvider;
 import com.meme.ala.core.auth.oauth.GoogleUser;
 import com.meme.ala.core.auth.oauth.NaverUser;
@@ -62,8 +63,9 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @PublishEvent
     @Transactional
-    public void join(OAuthUserInfo authUserInfo, String provider) {
+    public String join(OAuthUserInfo authUserInfo, String provider) {
         Member newMember = Member.builder()
                 .email(authUserInfo.getEmail())
                 .memberSetting(
@@ -81,6 +83,8 @@ public class MemberServiceImpl implements MemberService {
         memberCardService.assignCard(newMember, defaultCardNum);
         aggregationService.initAggregation(newMember);
         memberRepository.save(newMember);
+
+        return authUserInfo.getEmail();
     }
 
     @Override


### PR DESCRIPTION
#69 에도 달았듯이 memberId가 필요해서 join 메서드의 트랜잭션이 commit이 완료된 이후에 initFriendInfo를 호출해야 함.
사용자의 FriendInfo의 초기화의 경우, 비동기로 처리되어도 상관없기 때문에 이벤트 핸들러를 통해 처리를 했으며, `@TransactionalEventListener`의 phase 값을 통해 이벤트 처리 시점을 commit이 완료된 이후로 설정.

이벤트 발행의 경우, join 메서드 안에서 해도 되지만, AOP를 통해 처리하는 게 코드 상 깔끔하다고 판단 // [참고](https://supawer0728.github.io/2018/03/24/spring-event/)

InitEvent 엔티티의 경우, email 밖에 없지만, 추후 추가될지도 모르는 멤버변수가 있다고 판단해서 만들어 둚.
