### PR TITLE
Feat: 완성되지 않은 문장의 경우 기본 폰트 적용

### DIFF
--- a/src/main/java/com/meme/ala/domain/alacard/model/entity/cardSetting/Background.java
+++ b/src/main/java/com/meme/ala/domain/alacard/model/entity/cardSetting/Background.java
@@ -3,11 +3,13 @@ package com.meme.ala.domain.alacard.model.entity.cardSetting;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @Document("BACKGROUND")

--- a/src/main/java/com/meme/ala/domain/alacard/model/mapper/AlaCardMapper.java
+++ b/src/main/java/com/meme/ala/domain/alacard/model/mapper/AlaCardMapper.java
@@ -17,6 +17,8 @@ public interface AlaCardMapper {
     AlaCardMapper INSTANCE = Mappers.getMapper(AlaCardMapper.class);
 
     default AlaCardDto toDto(AlaCard alaCard, AlaCardSetting alaCardSetting, String sentence, List<WordCount> selectedWordList, Boolean isCompleted) {
+        if(!isCompleted)
+            alaCardSetting.getBackground().setFontColor("#B9FF46");
         return AlaCardDto.builder()
                 .alaCardSettingDto(AlaCardSettingMapper.INSTANCE.toDto(alaCardSetting))
                 .selectedWordList(selectedWordList.stream()

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -9,5 +9,5 @@ cloud.aws.stack.auto=false
 cloud.aws.s3.bucket=meme-ala-background
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.s3.bucket.url=https://s3.ap-northeast-2.amazonaws.com/meme-ala-background
-cloud.aws.credentials.accessKey=AKIAXN532WKOBZ6EK5ON
-cloud.aws.credentials.secretKey=anRnSjZzbzJrSTh1TkFNYnYzT3VuKzMvek4vV2J4K2FjbVVXRGtqcw==
+cloud.aws.credentials.accessKey=
+cloud.aws.credentials.secretKey=


### PR DESCRIPTION
- 현재는 alacardsetting에 있는 정보를 그냥 제공
- 그런데 완성되지 않은 경우에는 프론트에서 배경이미지 대신 까만색으로 뒷배경 이미지를 사용할 것이기 때문에 배경이미지는 프론트에서 알아서 투명하게 적용할 것이고, 폰트색만 특정 색으로 바꿔서 보내달라고 요청하였음
- 그래서 DB에는 영향을 주지 않고 백에서 프론트에 넘겨줄때만 완성되지 않은 경우 폰트를 바꿔서 넘겨주는 거로 하였음