### PR TITLE
Feat: 사용자(단어리스트 제출자)를 세는 기능 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -225,4 +225,15 @@ include::{snippets}/api/v1/friend/nickname/delete/path-parameters.adoc[]
 .response
 include::{snippets}/api/v1/friend/nickname/delete/http-response.adoc[]
 
+== GET /api/v1/aggregation/usercount
+
+.request
+include::{snippets}/api/v1/aggregation/usercount/http-request.adoc[]
+
+.response
+include::{snippets}/api/v1/aggregation/usercount/http-response.adoc[]
+
+.response fields
+include::{snippets}/api/v1/aggregation/usercount/response-fields.adoc[]
+
 

--- a/src/main/java/com/meme/ala/core/aop/PublishEventAspect.java
+++ b/src/main/java/com/meme/ala/core/aop/PublishEventAspect.java
@@ -1,6 +1,7 @@
 package com.meme.ala.core.aop;
 
 import com.meme.ala.domain.event.model.entity.InitEvent;
+import com.meme.ala.domain.event.model.entity.SubmitEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
@@ -26,6 +27,10 @@ public class PublishEventAspect implements ApplicationEventPublisherAware {
         log.info(method + "가 실행됩니다.");
         if(method.equals("join")){
             InitEvent event = new InitEvent((String) returnObj);
+            eventPublisher.publishEvent(event);
+        }
+        else if(method.equals("submitWordList")){
+            SubmitEvent event = new SubmitEvent();
             eventPublisher.publishEvent(event);
         }
     }

--- a/src/main/java/com/meme/ala/domain/aggregation/controller/AggregationController.java
+++ b/src/main/java/com/meme/ala/domain/aggregation/controller/AggregationController.java
@@ -1,0 +1,24 @@
+package com.meme.ala.domain.aggregation.controller;
+
+import com.meme.ala.common.dto.ResponseDto;
+import com.meme.ala.common.message.ResponseMessage;
+import com.meme.ala.domain.aggregation.service.AggregationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(value = "/api/v1/aggregation")
+@RequiredArgsConstructor
+@RestController
+public class AggregationController {
+    private final AggregationService aggregationService;
+
+    @GetMapping("/usercount")
+    public ResponseEntity<ResponseDto<Integer>> getUserCount() {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.SUCCESS, aggregationService.getUserCount()));
+    }
+}

--- a/src/main/java/com/meme/ala/domain/aggregation/model/entity/UserCount.java
+++ b/src/main/java/com/meme/ala/domain/aggregation/model/entity/UserCount.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
@@ -13,6 +14,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @AllArgsConstructor
 @Document(collection = "USERCOUNT")
 public class UserCount {
+    @Id
     ObjectId id;
     private int count;
 }

--- a/src/main/java/com/meme/ala/domain/aggregation/model/entity/UserCount.java
+++ b/src/main/java/com/meme/ala/domain/aggregation/model/entity/UserCount.java
@@ -1,0 +1,18 @@
+package com.meme.ala.domain.aggregation.model.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@Document(collection = "USERCOUNT")
+public class UserCount {
+    ObjectId id;
+    private int count;
+}

--- a/src/main/java/com/meme/ala/domain/aggregation/repository/UserCountRepository.java
+++ b/src/main/java/com/meme/ala/domain/aggregation/repository/UserCountRepository.java
@@ -1,0 +1,10 @@
+package com.meme.ala.domain.aggregation.repository;
+
+import com.meme.ala.domain.aggregation.model.entity.UserCount;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserCountRepository extends MongoRepository<UserCount, ObjectId> {
+}

--- a/src/main/java/com/meme/ala/domain/aggregation/service/AggregationService.java
+++ b/src/main/java/com/meme/ala/domain/aggregation/service/AggregationService.java
@@ -14,4 +14,6 @@ public interface AggregationService {
     public void save(Aggregation aggregation);
 
     public void submitWordList(Member member, Aggregation aggregation, List<SelectionWordDto> wordDtoList);
+
+    public Integer getUserCount();
 }

--- a/src/main/java/com/meme/ala/domain/aggregation/service/AggregationServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/aggregation/service/AggregationServiceImpl.java
@@ -1,5 +1,6 @@
 package com.meme.ala.domain.aggregation.service;
 
+import com.meme.ala.core.annotation.PublishEvent;
 import com.meme.ala.core.error.ErrorCode;
 import com.meme.ala.core.error.exception.BusinessException;
 import com.meme.ala.domain.aggregation.model.entity.Aggregation;
@@ -69,6 +70,7 @@ public class AggregationServiceImpl implements AggregationService {
     }
 
     @Override
+    @PublishEvent
     @Transactional
     public void submitWordList(Member member, Aggregation aggregation, List<SelectionWordDto> wordDtoList) {
         Map<String, List<String>> dtoMap = dtoListToMapByMiddleCategory(wordDtoList);

--- a/src/main/java/com/meme/ala/domain/aggregation/service/AggregationServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/aggregation/service/AggregationServiceImpl.java
@@ -4,8 +4,10 @@ import com.meme.ala.core.annotation.PublishEvent;
 import com.meme.ala.core.error.ErrorCode;
 import com.meme.ala.core.error.exception.BusinessException;
 import com.meme.ala.domain.aggregation.model.entity.Aggregation;
+import com.meme.ala.domain.aggregation.model.entity.UserCount;
 import com.meme.ala.domain.aggregation.model.entity.WordCount;
 import com.meme.ala.domain.aggregation.repository.AggregationRepository;
+import com.meme.ala.domain.aggregation.repository.UserCountRepository;
 import com.meme.ala.domain.alacard.model.dto.response.SelectionWordDto;
 import com.meme.ala.domain.alacard.model.entity.MiddleCategory;
 import com.meme.ala.domain.member.model.entity.AlaCardSettingPair;
@@ -26,6 +28,7 @@ import java.util.stream.Stream;
 @Service
 public class AggregationServiceImpl implements AggregationService {
     private final AggregationRepository aggregationRepository;
+    private final UserCountRepository userCountRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -86,6 +89,12 @@ public class AggregationServiceImpl implements AggregationService {
             }
         }
         aggregationRepository.save(aggregation);
+    }
+
+    @Override
+    public Integer getUserCount() {
+        UserCount userCount = userCountRepository.findAll().get(0);
+        return userCount.getCount();
     }
 
     private Map<String, List<String>> dtoListToMapByMiddleCategory(List<SelectionWordDto> wordDtoList) {

--- a/src/main/java/com/meme/ala/domain/event/model/entity/SubmitEvent.java
+++ b/src/main/java/com/meme/ala/domain/event/model/entity/SubmitEvent.java
@@ -1,0 +1,9 @@
+package com.meme.ala.domain.event.model.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SubmitEvent {
+}

--- a/src/test/java/com/meme/ala/domain/aggregation/controller/AggregationControllerTest.java
+++ b/src/test/java/com/meme/ala/domain/aggregation/controller/AggregationControllerTest.java
@@ -1,0 +1,43 @@
+package com.meme.ala.domain.aggregation.controller;
+
+import com.meme.ala.common.AbstractControllerTest;
+import com.meme.ala.domain.aggregation.service.AggregationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static com.meme.ala.core.config.ApiDocumentUtils.getDocumentRequest;
+import static com.meme.ala.core.config.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class AggregationControllerTest extends AbstractControllerTest {
+    @MockBean
+    AggregationService aggregationService;
+
+    @DisplayName("사용자의 수를 제공하는 테스트")
+    @Test
+    public void 사용자의_수를_제공하는_테스트() throws Exception {
+        given(aggregationService.getUserCount()).willReturn(5);
+        mockMvc.perform(get("/api/v1/aggregation/usercount"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data").value(5))
+                .andDo(print())
+                .andDo(document("api/v1/aggregation/usercount",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        responseFields(
+                                fieldWithPath("status").description("응답 상태"),
+                                fieldWithPath("message").description("설명"),
+                                fieldWithPath("data").description("선택된 카드"),
+                                fieldWithPath("timestamp").description("타임스탬프")
+                        )
+                ));
+    }
+}


### PR DESCRIPTION
- UserCount 엔티티(도큐먼트) 생성
- AOP와 Event를 이용하여 submitWordList 메소드 이후에 비동기로 usercount를 1 올림
- usercount 객체가 DB에 없을 경우에는 1로 초기화해서 저장하도록 구현