### PR TITLE
Feat: Alarm 관련 도메인 정의

### DIFF
--- a/src/main/java/com/meme/ala/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/com/meme/ala/domain/alarm/controller/AlarmController.java
@@ -11,8 +11,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
-
 @RequestMapping(value = "/api/v1/alarm")
 @RestController
 @RequiredArgsConstructor
@@ -21,21 +19,17 @@ public class AlarmController {
 
     //TODO: 테스트 코드는 지울 예정
     @GetMapping("/test")
-    public void saveTest(){
+    public void saveTest() {
         Alarm friendAlarm = FriendAlarm.builder().friendId(new ObjectId())
                 .memberId(new ObjectId())
                 .data("testFriendData")
                 .category(AlarmCategory.FRIEND_ALARM)
-                .createdAt(LocalDateTime.now())
-                .expireAt(LocalDateTime.now().plusDays(30))
                 .build();
 
         Alarm noticeAlarm = NoticeAlarm.builder().redirectUrl("http://testurl.com")
                 .memberId(new ObjectId())
                 .data("testNoticeData")
-                .category(AlarmCategory.FRIEND_ALARM)
-                .createdAt(LocalDateTime.now())
-                .expireAt(LocalDateTime.now().plusDays(30))
+                .category(AlarmCategory.NOTICE_ALARM)
                 .build();
         alarmRepository.save(friendAlarm);
         alarmRepository.save(noticeAlarm);

--- a/src/main/java/com/meme/ala/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/com/meme/ala/domain/alarm/controller/AlarmController.java
@@ -1,0 +1,43 @@
+package com.meme.ala.domain.alarm.controller;
+
+import com.meme.ala.domain.alarm.model.entity.Alarm;
+import com.meme.ala.domain.alarm.model.entity.AlarmCategory;
+import com.meme.ala.domain.alarm.model.entity.FriendAlarm;
+import com.meme.ala.domain.alarm.model.entity.NoticeAlarm;
+import com.meme.ala.domain.alarm.repository.AlarmRepository;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@RequestMapping(value = "/api/v1/alarm")
+@RestController
+@RequiredArgsConstructor
+public class AlarmController {
+    private final AlarmRepository alarmRepository;
+
+    //TODO: 테스트 코드는 지울 예정
+    @GetMapping("/test")
+    public void saveTest(){
+        Alarm friendAlarm = FriendAlarm.builder().friendId(new ObjectId())
+                .memberId(new ObjectId())
+                .data("testFriendData")
+                .category(AlarmCategory.FRIEND_ALARM)
+                .createdAt(LocalDateTime.now())
+                .expireAt(LocalDateTime.now().plusDays(30))
+                .build();
+
+        Alarm noticeAlarm = NoticeAlarm.builder().redirectUrl("http://testurl.com")
+                .memberId(new ObjectId())
+                .data("testNoticeData")
+                .category(AlarmCategory.FRIEND_ALARM)
+                .createdAt(LocalDateTime.now())
+                .expireAt(LocalDateTime.now().plusDays(30))
+                .build();
+        alarmRepository.save(friendAlarm);
+        alarmRepository.save(noticeAlarm);
+    }
+}

--- a/src/main/java/com/meme/ala/domain/alarm/model/entity/Alarm.java
+++ b/src/main/java/com/meme/ala/domain/alarm/model/entity/Alarm.java
@@ -1,0 +1,28 @@
+package com.meme.ala.domain.alarm.model.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Document(collection = "ALARM")
+public class Alarm {
+    @Id
+    private ObjectId id;
+
+    private ObjectId memberId;
+
+    private String data;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime expireAt;
+
+    private AlarmCategory category;
+}

--- a/src/main/java/com/meme/ala/domain/alarm/model/entity/Alarm.java
+++ b/src/main/java/com/meme/ala/domain/alarm/model/entity/Alarm.java
@@ -1,16 +1,17 @@
 package com.meme.ala.domain.alarm.model.entity;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
+@SuperBuilder
 @Document(collection = "ALARM")
 public class Alarm {
     @Id
@@ -20,9 +21,12 @@ public class Alarm {
 
     private String data;
 
-    private LocalDateTime createdAt;
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
 
-    private LocalDateTime expireAt;
+    @Builder.Default
+    @Indexed(expireAfterSeconds = 60)
+    private LocalDateTime expireAt = LocalDateTime.now().plusSeconds(60);
 
     private AlarmCategory category;
 }

--- a/src/main/java/com/meme/ala/domain/alarm/model/entity/AlarmCategory.java
+++ b/src/main/java/com/meme/ala/domain/alarm/model/entity/AlarmCategory.java
@@ -1,0 +1,5 @@
+package com.meme.ala.domain.alarm.model.entity;
+
+public enum AlarmCategory {
+    NOTICE_ALARM, FRIEND_ALARM
+}

--- a/src/main/java/com/meme/ala/domain/alarm/model/entity/FriendAlarm.java
+++ b/src/main/java/com/meme/ala/domain/alarm/model/entity/FriendAlarm.java
@@ -1,24 +1,17 @@
 package com.meme.ala.domain.alarm.model.entity;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Setter
+@SuperBuilder
 @Document(collection = "ALARM")
 @TypeAlias("FriendAlarm")
 public class FriendAlarm extends Alarm {
     private ObjectId friendId;
-
-    @Builder
-    public FriendAlarm(ObjectId id, ObjectId memberId, String data, LocalDateTime createdAt, LocalDateTime expireAt, AlarmCategory category, ObjectId friendId) {
-        super(id, memberId, data, createdAt, expireAt, category);
-        this.friendId = friendId;
-    }
 }

--- a/src/main/java/com/meme/ala/domain/alarm/model/entity/FriendAlarm.java
+++ b/src/main/java/com/meme/ala/domain/alarm/model/entity/FriendAlarm.java
@@ -1,0 +1,24 @@
+package com.meme.ala.domain.alarm.model.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.TypeAlias;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Document(collection = "ALARM")
+@TypeAlias("FriendAlarm")
+public class FriendAlarm extends Alarm {
+    private ObjectId friendId;
+
+    @Builder
+    public FriendAlarm(ObjectId id, ObjectId memberId, String data, LocalDateTime createdAt, LocalDateTime expireAt, AlarmCategory category, ObjectId friendId) {
+        super(id, memberId, data, createdAt, expireAt, category);
+        this.friendId = friendId;
+    }
+}

--- a/src/main/java/com/meme/ala/domain/alarm/model/entity/NoticeAlarm.java
+++ b/src/main/java/com/meme/ala/domain/alarm/model/entity/NoticeAlarm.java
@@ -1,24 +1,16 @@
 package com.meme.ala.domain.alarm.model.entity;
 
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import org.bson.types.ObjectId;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Setter
+@SuperBuilder
 @Document(collection = "ALARM")
 @TypeAlias("NoticeAlarm")
 public class NoticeAlarm extends Alarm {
     private String redirectUrl;
-
-    @Builder
-    public NoticeAlarm(ObjectId id, ObjectId memberId, String data, LocalDateTime createdAt, LocalDateTime expireAt, AlarmCategory category, String redirectUrl) {
-        super(id, memberId, data, createdAt, expireAt, category);
-        this.redirectUrl = redirectUrl;
-    }
 }

--- a/src/main/java/com/meme/ala/domain/alarm/model/entity/NoticeAlarm.java
+++ b/src/main/java/com/meme/ala/domain/alarm/model/entity/NoticeAlarm.java
@@ -1,0 +1,24 @@
+package com.meme.ala.domain.alarm.model.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.TypeAlias;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Document(collection = "ALARM")
+@TypeAlias("NoticeAlarm")
+public class NoticeAlarm extends Alarm {
+    private String redirectUrl;
+
+    @Builder
+    public NoticeAlarm(ObjectId id, ObjectId memberId, String data, LocalDateTime createdAt, LocalDateTime expireAt, AlarmCategory category, String redirectUrl) {
+        super(id, memberId, data, createdAt, expireAt, category);
+        this.redirectUrl = redirectUrl;
+    }
+}

--- a/src/main/java/com/meme/ala/domain/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/meme/ala/domain/alarm/repository/AlarmRepository.java
@@ -1,0 +1,8 @@
+package com.meme.ala.domain.alarm.repository;
+
+import com.meme.ala.domain.alarm.model.entity.Alarm;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface AlarmRepository extends MongoRepository<Alarm, ObjectId> {
+}


### PR DESCRIPTION
- Alarm은 상속 용도로 정의함
- FriendAlarm, NoticeAlarm의 자식클래스가 alarm을 상속받도록 구현
- @TypeAlias를 이용하여 MongoDB에 FriendAlarm 형태로 저장되도록 함
- AlarmController에서 테스트완료(Repository 테스트 불가하므로 테스트 코드는 지울 예정)

현우 너가 ERD 짜준거 보면서 생각해봤는데 뭔가 Composition으로 FriendAlarm, NoticeAlarm을 박고 Nullable로 설정하면 뭔가 설계상 찜찜했던점
그리고 앞으로 혹시 또다른 알람들(EventAlarm, EmergencyAlarm)같은게 나올때마다 Alarm 클래스를 변경해주면 기존에 이미 저장되어 있는 데이터들의 스키마가 깨지게 되는 점 때문에 고민하다가

Alarm을 상속받도록 구현해봤어! TypeAlias라는 좋은게 있더라구
테스트코드도 Polymorphism 적용해도 진짜 사용 가능하다는걸 알려주는 코드로 작성해봤으니까 한번 어떤지 확인해주라! 데이터베이스에서는 이렇게 이쁘게 저장돼

![image](https://user-images.githubusercontent.com/46064193/128606625-897abf53-16a0-4710-85a8-fd0dcb2e8329.png)

[추가테스트]
AlarmRepository로 가져와서 자식 클래스로 사용가능한지 테스트해봄
![image](https://user-images.githubusercontent.com/46064193/128606793-58ef702e-afb8-4db7-94a5-bdd23620a968.png)

![image](https://user-images.githubusercontent.com/46064193/128606808-54d1f86f-1ac7-4df5-a3f8-b5182820cec6.png)

