### PR TITLE
Feature 121,122/friend relation and refactor entity

### DIFF
--- a/src/main/java/com/meme/ala/common/message/ResponseMessage.java
+++ b/src/main/java/com/meme/ala/common/message/ResponseMessage.java
@@ -12,4 +12,5 @@ public class ResponseMessage {
     public static final String DELETED = "deleted";
     public static final String SUBMITTED = "submitted";
     public static final String READ_MEMBER_FRIENDS = "사용자 친구 목록을 조회합니다.";
+    public static final String READ_MEMBER_AND_PERSON_RELATION = "사용자와 상대방의 관계를 조회합니다.";
 }

--- a/src/main/java/com/meme/ala/core/error/ErrorCode.java
+++ b/src/main/java/com/meme/ala/core/error/ErrorCode.java
@@ -18,7 +18,10 @@ public enum ErrorCode {
 
     // Friend
     ALREADY_FRIEND(400, "F001", "Already Friend"),
-    NOT_FRIEND(400, "F002", "Not Friend")
+    NOT_FRIEND(400, "F002", "Not Friend"),
+    NOT_FOLLOWING(400, "F003", "Not Following"),
+    NOT_FOLLOWER(400, "F004", "Not Follower"),
+    NOT_DEFAULT(400, "F005", "Not Default")
     ;
 
     private final String code;

--- a/src/main/java/com/meme/ala/domain/event/component/EventHandler.java
+++ b/src/main/java/com/meme/ala/domain/event/component/EventHandler.java
@@ -7,7 +7,7 @@ import com.meme.ala.domain.aggregation.repository.UserCountRepository;
 import com.meme.ala.domain.aggregation.service.AggregationService;
 import com.meme.ala.domain.event.model.entity.InitEvent;
 import com.meme.ala.domain.event.model.entity.SubmitEvent;
-import com.meme.ala.domain.friend.service.FriendService;
+import com.meme.ala.domain.friend.service.FriendInfoService;
 import com.meme.ala.domain.member.model.entity.Member;
 import com.meme.ala.domain.member.repository.MemberRepository;
 import com.meme.ala.domain.member.service.MemberCardService;
@@ -23,7 +23,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class EventHandler {
     @Value("${member.alacardnum}")
     private int defaultCardNum;
-    private final FriendService friendService;
+    private final FriendInfoService friendInfoService;
     private final AggregationService aggregationService;
     private final MemberCardService memberCardService;
     private final MemberRepository memberRepository;
@@ -36,7 +36,7 @@ public class EventHandler {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
         memberCardService.assignCard(member, defaultCardNum);
         aggregationService.initAggregation(member);
-        friendService.initFriendInfo(member);
+        friendInfoService.initFriendInfo(member);
     }
 
     @Async

--- a/src/main/java/com/meme/ala/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/meme/ala/domain/friend/controller/FriendController.java
@@ -66,7 +66,7 @@ public class FriendController {
     public ResponseEntity<ResponseDto> deleteMemberFriend(@CurrentUser Member member, @PathVariable String nickname){
         Member friend = memberService.findByNickname(nickname);
 
-        friendInfoService.cutOffFriend(member, friend);
+        friendInfoService.unFriend(member, friend);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .body(ResponseDto.of(HttpStatus.NO_CONTENT, ResponseMessage.DELETED));

--- a/src/main/java/com/meme/ala/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/meme/ala/domain/friend/controller/FriendController.java
@@ -6,7 +6,7 @@ import com.meme.ala.common.message.ResponseMessage;
 import com.meme.ala.domain.friend.model.dto.FriendDto;
 import com.meme.ala.domain.member.model.entity.Member;
 import com.meme.ala.domain.friend.model.mapper.FriendMapper;
-import com.meme.ala.domain.friend.service.FriendService;
+import com.meme.ala.domain.friend.service.FriendInfoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,12 +19,12 @@ import java.util.stream.Collectors;
 @RestController
 @RequiredArgsConstructor
 public class FriendController {
-    private final FriendService friendService;
+    private final FriendInfoService friendInfoService;
     private final FriendMapper friendMapper;
 
     @GetMapping
     public ResponseEntity<ResponseDto<List<FriendDto>>> getMemberFriends(@CurrentUser Member member) {
-        List<Member> memberFriendList = friendService.getMemberFriend(member);
+        List<Member> memberFriendList = friendInfoService.getMemberFriend(member);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.READ_MEMBER_FRIENDS,
@@ -32,10 +32,9 @@ public class FriendController {
                 );
     }
 
-
     @PostMapping("/{nickname}")
     public ResponseEntity<ResponseDto> addMemberFriend(@CurrentUser Member member, @PathVariable String nickname){
-        friendService.addMemberFriend(member, nickname);
+        friendInfoService.followingFriend(member, nickname);
 
         return ResponseEntity.status(HttpStatus.OK)
                     .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.SUCCESS));
@@ -43,7 +42,7 @@ public class FriendController {
 
     @PostMapping("/accept/{nickname}")
     public ResponseEntity<ResponseDto> acceptMemberFriend(@CurrentUser Member member, @PathVariable String nickname){
-        friendService.acceptMemberFriend(member, nickname);
+        friendInfoService.acceptFollowerToFriend(member, nickname);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.SUCCESS));
@@ -52,7 +51,7 @@ public class FriendController {
     @DeleteMapping("/{nickname}")
     public ResponseEntity<ResponseDto> deleteMemberFriend(@CurrentUser Member member, @PathVariable String nickname){
 
-        friendService.deleteMemberFriend(member, nickname);
+        friendInfoService.cutOffFriend(member, nickname);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .body(ResponseDto.of(HttpStatus.NO_CONTENT, ResponseMessage.DELETED));

--- a/src/main/java/com/meme/ala/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/meme/ala/domain/friend/controller/FriendController.java
@@ -4,9 +4,12 @@ import com.meme.ala.common.annotation.CurrentUser;
 import com.meme.ala.common.dto.ResponseDto;
 import com.meme.ala.common.message.ResponseMessage;
 import com.meme.ala.domain.friend.model.dto.FriendDto;
+import com.meme.ala.domain.friend.model.dto.FriendRelationDto;
+import com.meme.ala.domain.friend.model.entity.FriendRelation;
 import com.meme.ala.domain.member.model.entity.Member;
 import com.meme.ala.domain.friend.model.mapper.FriendMapper;
 import com.meme.ala.domain.friend.service.FriendInfoService;
+import com.meme.ala.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +24,7 @@ import java.util.stream.Collectors;
 public class FriendController {
     private final FriendInfoService friendInfoService;
     private final FriendMapper friendMapper;
+    private final MemberService memberService;
 
     @GetMapping
     public ResponseEntity<ResponseDto<List<FriendDto>>> getMemberFriends(@CurrentUser Member member) {
@@ -32,9 +36,18 @@ public class FriendController {
                 );
     }
 
+    @GetMapping("/relation/{nickname}")
+    public ResponseEntity<ResponseDto<FriendRelationDto>> getRelationWithFriend(@CurrentUser Member member, @PathVariable String nickname){
+        Member person =  memberService.findByNickname(nickname);
+        FriendRelation relation = friendInfoService.getRelation(member, person);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.READ_MEMBER_AND_PERSON_RELATION, new FriendRelationDto(nickname, relation.getKrRelation())));
+    }
+
     @PostMapping("/{nickname}")
     public ResponseEntity<ResponseDto> addMemberFriend(@CurrentUser Member member, @PathVariable String nickname){
-        friendInfoService.followingFriend(member, nickname);
+        Member following = memberService.findByNickname(nickname);
+        friendInfoService.followingFriend(member, following);
 
         return ResponseEntity.status(HttpStatus.OK)
                     .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.SUCCESS));
@@ -42,7 +55,8 @@ public class FriendController {
 
     @PostMapping("/accept/{nickname}")
     public ResponseEntity<ResponseDto> acceptMemberFriend(@CurrentUser Member member, @PathVariable String nickname){
-        friendInfoService.acceptFollowerToFriend(member, nickname);
+        Member follower = memberService.findByNickname(nickname);
+        friendInfoService.acceptFollowerToFriend(member, follower);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.SUCCESS));
@@ -50,8 +64,9 @@ public class FriendController {
 
     @DeleteMapping("/{nickname}")
     public ResponseEntity<ResponseDto> deleteMemberFriend(@CurrentUser Member member, @PathVariable String nickname){
+        Member friend = memberService.findByNickname(nickname);
 
-        friendInfoService.cutOffFriend(member, nickname);
+        friendInfoService.cutOffFriend(member, friend);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .body(ResponseDto.of(HttpStatus.NO_CONTENT, ResponseMessage.DELETED));

--- a/src/main/java/com/meme/ala/domain/friend/model/dto/FriendRelationDto.java
+++ b/src/main/java/com/meme/ala/domain/friend/model/dto/FriendRelationDto.java
@@ -1,0 +1,14 @@
+package com.meme.ala.domain.friend.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class FriendRelationDto {
+    private String nickname;
+    private String relation;
+}

--- a/src/main/java/com/meme/ala/domain/friend/model/entity/FriendInfo.java
+++ b/src/main/java/com/meme/ala/domain/friend/model/entity/FriendInfo.java
@@ -1,5 +1,8 @@
 package com.meme.ala.domain.friend.model.entity;
 
+import com.meme.ala.core.error.ErrorCode;
+import com.meme.ala.core.error.exception.EntityNotFoundException;
+import com.meme.ala.domain.member.model.entity.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,5 +27,19 @@ public class FriendInfo {
     private List<ObjectId> friends = new LinkedList<>();
 
     @Builder.Default
-    private List<ObjectId> pendings = new LinkedList<>();
+    private List<ObjectId> myAcceptancePendingList = new LinkedList<>();
+
+    @Builder.Default
+    private List<ObjectId> friendAcceptancePendingList = new LinkedList<>();
+
+    public FriendRelation getRelation(ObjectId friendId){
+        if(friends.contains(friendId))
+            return FriendRelation.FRIEND;
+        else if(myAcceptancePendingList.contains(friendId))
+            return FriendRelation.FOLLOWER;
+        else if(friendAcceptancePendingList.contains(friendId))
+            return FriendRelation.FOLLOWING;
+        else
+            return FriendRelation.DEFAULT;
+    }
 }

--- a/src/main/java/com/meme/ala/domain/friend/model/entity/FriendRelation.java
+++ b/src/main/java/com/meme/ala/domain/friend/model/entity/FriendRelation.java
@@ -1,14 +1,17 @@
 package com.meme.ala.domain.friend.model.entity;
 
-import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 public enum FriendRelation {
     DEFAULT("일반"),
     FOLLOWING("팔로잉"),
     FOLLOWER("팔로워"),
     FRIEND("친구");
 
-    private FriendRelation(String relation){
-    }
+    private final String krRelation;
 
+    private FriendRelation(String krRelation){
+        this.krRelation = krRelation;
+    }
 }

--- a/src/main/java/com/meme/ala/domain/friend/model/entity/FriendRelation.java
+++ b/src/main/java/com/meme/ala/domain/friend/model/entity/FriendRelation.java
@@ -11,7 +11,7 @@ public enum FriendRelation {
 
     private final String krRelation;
 
-    private FriendRelation(String krRelation){
+    FriendRelation(String krRelation){
         this.krRelation = krRelation;
     }
 }

--- a/src/main/java/com/meme/ala/domain/friend/model/entity/FriendRelation.java
+++ b/src/main/java/com/meme/ala/domain/friend/model/entity/FriendRelation.java
@@ -1,0 +1,14 @@
+package com.meme.ala.domain.friend.model.entity;
+
+import lombok.AllArgsConstructor;
+
+public enum FriendRelation {
+    DEFAULT("일반"),
+    FOLLOWING("팔로잉"),
+    FOLLOWER("팔로워"),
+    FRIEND("친구");
+
+    private FriendRelation(String relation){
+    }
+
+}

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendInfoService.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendInfoService.java
@@ -1,13 +1,15 @@
 package com.meme.ala.domain.friend.service;
 
+import com.meme.ala.domain.friend.model.entity.FriendRelation;
 import com.meme.ala.domain.member.model.entity.Member;
 
 import java.util.List;
 
 public interface FriendInfoService {
     List<Member> getMemberFriend(Member member);
-    void followingFriend(Member member, String followingNickname);
-    void acceptFollowerToFriend(Member member, String followerNickname);
-    void cutOffFriend(Member member, String friendNickname);
+    void followingFriend(Member member, Member following);
+    void acceptFollowerToFriend(Member member, Member follower);
+    void cutOffFriend(Member member, Member friend);
     void initFriendInfo(Member member);
+    FriendRelation getRelation(Member member, Member person);
 }

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendInfoService.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendInfoService.java
@@ -9,7 +9,7 @@ public interface FriendInfoService {
     List<Member> getMemberFriend(Member member);
     void followingFriend(Member member, Member following);
     void acceptFollowerToFriend(Member member, Member follower);
-    void cutOffFriend(Member member, Member friend);
+    void unFriend(Member member, Member friend);
     void initFriendInfo(Member member);
     FriendRelation getRelation(Member member, Member person);
 }

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendInfoService.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendInfoService.java
@@ -1,0 +1,13 @@
+package com.meme.ala.domain.friend.service;
+
+import com.meme.ala.domain.member.model.entity.Member;
+
+import java.util.List;
+
+public interface FriendInfoService {
+    List<Member> getMemberFriend(Member member);
+    void followingFriend(Member member, String followingNickname);
+    void acceptFollowerToFriend(Member member, String followerNickname);
+    void cutOffFriend(Member member, String friendNickname);
+    void initFriendInfo(Member member);
+}

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendInfoServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendInfoServiceImpl.java
@@ -9,6 +9,7 @@ import com.meme.ala.domain.member.model.entity.Member;
 import com.meme.ala.domain.friend.repository.FriendInfoRepository;
 import com.meme.ala.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +19,7 @@ import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
-public class FriendInfoServiceImpl implements FriendInfoService { // TODO: 각 메서드의 처음 4줄이 비슷한데 개선할 수 있나?
+public class FriendInfoServiceImpl implements FriendInfoService {
     private final FriendInfoRepository friendInfoRepository;
     private final MemberRepository memberRepository;
     private final FriendService friendService;
@@ -56,11 +57,8 @@ public class FriendInfoServiceImpl implements FriendInfoService { // TODO: 각 �
     @Override
     @Transactional
     public void followingFriend(Member member, Member following){
-        FriendInfo followingFriendInfo = friendInfoRepository.findById(following.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+        FriendInfo memberFriendInfo = getFriendInfo(member);
+        FriendInfo followingFriendInfo = getFriendInfo(following);
 
         if(memberFriendInfo.getRelation(following.getId()) != FriendRelation.DEFAULT)
             throw new BusinessException(ErrorCode.NOT_DEFAULT);
@@ -73,11 +71,8 @@ public class FriendInfoServiceImpl implements FriendInfoService { // TODO: 각 �
     @Override
     @Transactional
     public void acceptFollowerToFriend(Member member, Member follower){
-        FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        FriendInfo followerFriendInfo = friendInfoRepository.findById(follower.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+        FriendInfo memberFriendInfo = getFriendInfo(member);
+        FriendInfo followerFriendInfo = getFriendInfo(follower);
 
         if(memberFriendInfo.getRelation(follower.getId()) != FriendRelation.FOLLOWER)
             throw new BusinessException(ErrorCode.NOT_FOLLOWER);
@@ -90,11 +85,8 @@ public class FriendInfoServiceImpl implements FriendInfoService { // TODO: 각 �
     @Override
     @Transactional
     public void cutOffFriend(Member member, Member friend){
-        FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        FriendInfo friendFriendInfo = friendInfoRepository.findById(friend.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+        FriendInfo memberFriendInfo = getFriendInfo(member);
+        FriendInfo friendFriendInfo = getFriendInfo(friend);
 
         if(memberFriendInfo.getRelation(friend.getId()) != FriendRelation.FRIEND)
             throw new BusinessException(ErrorCode.NOT_FRIEND);
@@ -102,6 +94,11 @@ public class FriendInfoServiceImpl implements FriendInfoService { // TODO: 각 �
         friendService.cutOff(memberFriendInfo, friendFriendInfo);
 
         friendInfoRepository.saveAll(Arrays.asList(memberFriendInfo, friendFriendInfo));
+    }
+
+    private FriendInfo getFriendInfo(Member member){
+        return friendInfoRepository.findById(member.getId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendInfoServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendInfoServiceImpl.java
@@ -9,7 +9,6 @@ import com.meme.ala.domain.member.model.entity.Member;
 import com.meme.ala.domain.friend.repository.FriendInfoRepository;
 import com.meme.ala.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -84,14 +83,14 @@ public class FriendInfoServiceImpl implements FriendInfoService {
 
     @Override
     @Transactional
-    public void cutOffFriend(Member member, Member friend){
+    public void unFriend(Member member, Member friend){
         FriendInfo memberFriendInfo = getFriendInfo(member);
         FriendInfo friendFriendInfo = getFriendInfo(friend);
 
         if(memberFriendInfo.getRelation(friend.getId()) != FriendRelation.FRIEND)
             throw new BusinessException(ErrorCode.NOT_FRIEND);
 
-        friendService.cutOff(memberFriendInfo, friendFriendInfo);
+        friendService.unFriend(memberFriendInfo, friendFriendInfo);
 
         friendInfoRepository.saveAll(Arrays.asList(memberFriendInfo, friendFriendInfo));
     }

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendInfoServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendInfoServiceImpl.java
@@ -1,0 +1,108 @@
+package com.meme.ala.domain.friend.service;
+
+import com.meme.ala.core.error.ErrorCode;
+import com.meme.ala.core.error.exception.BusinessException;
+import com.meme.ala.core.error.exception.EntityNotFoundException;
+import com.meme.ala.domain.friend.model.entity.FriendInfo;
+import com.meme.ala.domain.friend.model.entity.FriendRelation;
+import com.meme.ala.domain.member.model.entity.Member;
+import com.meme.ala.domain.friend.repository.FriendInfoRepository;
+import com.meme.ala.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class FriendInfoServiceImpl implements FriendInfoService { // TODO: 각 메서드의 3줄이 비슷한데 개선할 수 있나?
+    private final FriendInfoRepository friendInfoRepository;
+    private final MemberRepository memberRepository;
+    private final FriendService friendService;
+
+    @Override
+    @Transactional
+    public void initFriendInfo(Member member){
+        FriendInfo friendInfo = FriendInfo.builder().memberId(member.getId()).build();
+
+        friendInfoRepository.save(friendInfo);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<Member> getMemberFriend(Member member) {
+        FriendInfo friendInfo = friendInfoRepository.findById(member.getId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        return friendInfo
+                .getFriends()
+                .stream()
+                .map((id) -> memberRepository.findById(id)
+                                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND)))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void followingFriend(Member member, String followingNickname){
+        Member following = memberRepository.findByMemberSettingNickname(followingNickname)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        FriendInfo followingFriendInfo = friendInfoRepository.findById(following.getId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        if(memberFriendInfo.getRelation(following.getId()) != FriendRelation.DEFAULT)
+            throw new BusinessException(ErrorCode.NOT_DEFAULT);
+
+        friendService.follow(memberFriendInfo, followingFriendInfo);
+
+        friendInfoRepository.saveAll(Arrays.asList(followingFriendInfo, memberFriendInfo));
+    }
+
+    @Override
+    @Transactional
+    public void acceptFollowerToFriend(Member member, String followerNickname){
+        Member follower = memberRepository.findByMemberSettingNickname(followerNickname)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        FriendInfo followerFriendInfo = friendInfoRepository.findById(follower.getId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        if(memberFriendInfo.getRelation(follower.getId()) != FriendRelation.FOLLOWER)
+            throw new BusinessException(ErrorCode.NOT_FOLLOWER);
+
+        friendService.accept(memberFriendInfo, followerFriendInfo);
+
+        friendInfoRepository.saveAll(Arrays.asList(memberFriendInfo, followerFriendInfo));
+    }
+
+    @Override
+    @Transactional
+    public void cutOffFriend(Member member, String friendNickname){
+        Member friend = memberRepository.findByMemberSettingNickname(friendNickname)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        FriendInfo friendFriendInfo = friendInfoRepository.findById(friend.getId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+
+        if(memberFriendInfo.getRelation(friend.getId()) != FriendRelation.FRIEND)
+            throw new BusinessException(ErrorCode.NOT_FRIEND);
+
+        friendService.cutOff(memberFriendInfo, friendFriendInfo);
+
+        friendInfoRepository.saveAll(Arrays.asList(memberFriendInfo, friendFriendInfo));
+    }
+
+}

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendInfoServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendInfoServiceImpl.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
-public class FriendInfoServiceImpl implements FriendInfoService { // TODO: 각 메서드의 3줄이 비슷한데 개선할 수 있나?
+public class FriendInfoServiceImpl implements FriendInfoService { // TODO: 각 메서드의 처음 4줄이 비슷한데 개선할 수 있나?
     private final FriendInfoRepository friendInfoRepository;
     private final MemberRepository memberRepository;
     private final FriendService friendService;
@@ -46,11 +46,16 @@ public class FriendInfoServiceImpl implements FriendInfoService { // TODO: 각 �
     }
 
     @Override
-    @Transactional
-    public void followingFriend(Member member, String followingNickname){
-        Member following = memberRepository.findByMemberSettingNickname(followingNickname)
+    public FriendRelation getRelation(Member member, Member person) {
+        FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
 
+        return memberFriendInfo.getRelation(person.getId());
+    }
+
+    @Override
+    @Transactional
+    public void followingFriend(Member member, Member following){
         FriendInfo followingFriendInfo = friendInfoRepository.findById(following.getId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
 
@@ -67,10 +72,7 @@ public class FriendInfoServiceImpl implements FriendInfoService { // TODO: 각 �
 
     @Override
     @Transactional
-    public void acceptFollowerToFriend(Member member, String followerNickname){
-        Member follower = memberRepository.findByMemberSettingNickname(followerNickname)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
+    public void acceptFollowerToFriend(Member member, Member follower){
         FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
 
@@ -87,10 +89,7 @@ public class FriendInfoServiceImpl implements FriendInfoService { // TODO: 각 �
 
     @Override
     @Transactional
-    public void cutOffFriend(Member member, String friendNickname){
-        Member friend = memberRepository.findByMemberSettingNickname(friendNickname)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
+    public void cutOffFriend(Member member, Member friend){
         FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
 

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendService.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendService.java
@@ -7,5 +7,5 @@ public interface FriendService {
     void accept(FriendInfo a, FriendInfo b); // a가 b를 수락하다
     void decline(FriendInfo a, FriendInfo b); // a가 b를 거절하다
     void cancelFollowing(FriendInfo a, FriendInfo b); // a가 b에게 친구 신청한 것을 취소하다
-    void cutOff(FriendInfo a, FriendInfo b); // a와 b가 절교하다
+    void unFriend(FriendInfo a, FriendInfo b); // a와 b가 친구사이를 끊다.
 }

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendService.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendService.java
@@ -1,13 +1,11 @@
 package com.meme.ala.domain.friend.service;
 
-import com.meme.ala.domain.member.model.entity.Member;
-
-import java.util.List;
+import com.meme.ala.domain.friend.model.entity.FriendInfo;
 
 public interface FriendService {
-    List<Member> getMemberFriend(Member member);
-    void addMemberFriend(Member member, String followingNickname);
-    void acceptMemberFriend(Member member, String followerNickname);
-    void deleteMemberFriend(Member member, String friendNickname);
-    void initFriendInfo(Member member);
+    void follow(FriendInfo a, FriendInfo b); // a가 b를 팔로우하다
+    void accept(FriendInfo a, FriendInfo b); // a가 b를 수락하다
+    void decline(FriendInfo a, FriendInfo b); // a가 b를 거절하다
+    void cancelFollowing(FriendInfo a, FriendInfo b); // a가 b에게 친구 신청한 것을 취소하다
+    void cutOff(FriendInfo a, FriendInfo b); // a와 b가 절교하다
 }

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendServiceImpl.java
@@ -1,7 +1,10 @@
 package com.meme.ala.domain.friend.service;
 
 import com.meme.ala.domain.friend.model.entity.FriendInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
 public class FriendServiceImpl implements FriendService{
     @Override
     public void follow(FriendInfo a, FriendInfo b) {

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendServiceImpl.java
@@ -1,118 +1,38 @@
 package com.meme.ala.domain.friend.service;
 
-import com.meme.ala.core.error.ErrorCode;
-import com.meme.ala.core.error.exception.BusinessException;
-import com.meme.ala.core.error.exception.EntityNotFoundException;
 import com.meme.ala.domain.friend.model.entity.FriendInfo;
-import com.meme.ala.domain.member.model.entity.Member;
-import com.meme.ala.domain.friend.repository.FriendInfoRepository;
-import com.meme.ala.domain.member.repository.MemberRepository;
-import lombok.RequiredArgsConstructor;
-import org.bson.types.ObjectId;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-@RequiredArgsConstructor
-@Service
-public class FriendServiceImpl implements FriendService {
-    private final FriendInfoRepository friendInfoRepository;
-    private final MemberRepository memberRepository;
-
+public class FriendServiceImpl implements FriendService{
     @Override
-    @Transactional(readOnly = true)
-    public List<Member> getMemberFriend(Member member) {
-        FriendInfo friendInfo = friendInfoRepository.findById(member.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        return friendInfo
-                .getFriends()
-                .stream()
-                .map((id) -> memberRepository.findById(id)
-                                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND)))
-                .collect(Collectors.toList());
+    public void follow(FriendInfo a, FriendInfo b) {
+        b.getMyAcceptancePendingList().add(a.getMemberId());
+        a.getFriendAcceptancePendingList().add(b.getMemberId());
     }
 
     @Override
-    @Transactional
-    public void addMemberFriend(Member member, String followingNickname){
-        Member following = memberRepository.findByMemberSettingNickname(followingNickname)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+    public void accept(FriendInfo a, FriendInfo b) {
+        a.getMyAcceptancePendingList().remove(b.getMemberId());
+        b.getFriendAcceptancePendingList().remove(a.getMemberId());
 
-        FriendInfo followingFriendInfo = friendInfoRepository.findById(following.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        if(isFriend(member, following))
-            throw new BusinessException(ErrorCode.ALREADY_FRIEND);
-
-        followingFriendInfo.getPendings().add(member.getId());
-
-        friendInfoRepository.save(followingFriendInfo);
+        a.getFriends().add(b.getMemberId());
+        b.getFriends().add(a.getMemberId());
     }
 
     @Override
-    @Transactional
-    public void acceptMemberFriend(Member member, String followerNickname){
-        Member follower = memberRepository.findByMemberSettingNickname(followerNickname)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        FriendInfo followerFriendInfo = friendInfoRepository.findById(follower.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        if(!memberFriendInfo.getPendings().contains(follower.getId()))
-            throw new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND);
-
-        memberFriendInfo.getPendings().remove(follower.getId());
-
-        memberFriendInfo.getFriends().add(follower.getId());
-
-        followerFriendInfo.getFriends().add(member.getId());
-
-        friendInfoRepository.saveAll(Arrays.asList(memberFriendInfo, followerFriendInfo));
+    public void decline(FriendInfo a, FriendInfo b) {
+        a.getMyAcceptancePendingList().remove(b.getMemberId());
+        b.getFriendAcceptancePendingList().remove(a.getMemberId());
     }
 
     @Override
-    @Transactional
-    public void deleteMemberFriend(Member member, String friendNickname){
-        Member friend = memberRepository.findByMemberSettingNickname(friendNickname)
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        FriendInfo friendFriendInfo = friendInfoRepository.findById(friend.getId())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        if(!isFriend(member, friend))
-            throw new BusinessException(ErrorCode.NOT_FRIEND);
-
-        memberFriendInfo.getFriends().remove(friend.getId());
-
-        friendFriendInfo.getFriends().remove(member.getId());
-
-        friendInfoRepository.saveAll(Arrays.asList(memberFriendInfo, friendFriendInfo));
+    public void cancelFollowing(FriendInfo a, FriendInfo b) {
+        b.getMyAcceptancePendingList().remove(a.getMemberId());
+        a.getFriendAcceptancePendingList().remove(b.getMemberId());
     }
 
     @Override
-    @Transactional
-    public void initFriendInfo(Member member){
-        FriendInfo friendInfo = FriendInfo.builder().memberId(member.getId()).build();
-
-        friendInfoRepository.save(friendInfo);
+    public void cutOff(FriendInfo a, FriendInfo b) {
+        a.getFriends().remove(b.getMemberId());
+        b.getFriends().remove(a.getMemberId());
     }
-
-    private boolean isFriend(Member member, Member friend){
-        FriendInfo memberFriendInfo = friendInfoRepository.findById(member.getId())
-                    .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
-
-        return memberFriendInfo.getFriends().contains(friend.getId());
-    }
-
 }

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendServiceImpl.java
@@ -34,7 +34,7 @@ public class FriendServiceImpl implements FriendService{
     }
 
     @Override
-    public void cutOff(FriendInfo a, FriendInfo b) {
+    public void unFriend(FriendInfo a, FriendInfo b) {
         a.getFriends().remove(b.getMemberId());
         b.getFriends().remove(a.getMemberId());
     }

--- a/src/test/java/com/meme/ala/common/EntityFactory.java
+++ b/src/test/java/com/meme/ala/common/EntityFactory.java
@@ -82,7 +82,7 @@ public class EntityFactory {
         return FriendInfo.builder()
                 .memberId(new ObjectId(testObjectId() + "1"))
                 .friends(friends)
-                .pendings(pendings)
+                .myAcceptancePendingList(pendings)
                 .build();
     }
 

--- a/src/test/java/com/meme/ala/domain/friend/controller/FriendControllerTest.java
+++ b/src/test/java/com/meme/ala/domain/friend/controller/FriendControllerTest.java
@@ -4,7 +4,7 @@ import com.meme.ala.common.AbstractControllerTest;
 import com.meme.ala.common.EntityFactory;
 import com.meme.ala.core.config.AlaWithAccount;
 import com.meme.ala.domain.member.model.entity.Member;
-import com.meme.ala.domain.friend.service.FriendService;
+import com.meme.ala.domain.friend.service.FriendInfoService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class FriendControllerTest extends AbstractControllerTest {
 
     @MockBean
-    private FriendService memberFriendService;
+    private FriendInfoService memberFriendInfoService;
 
     @AlaWithAccount("test@gmail.com")
     @Test
@@ -37,7 +37,7 @@ public class FriendControllerTest extends AbstractControllerTest {
 
         List<Member> friends = Arrays.asList(EntityFactory.testMember());
 
-        given(memberFriendService.getMemberFriend(any(Member.class))).willReturn(friends);
+        given(memberFriendInfoService.getMemberFriend(any(Member.class))).willReturn(friends);
 
         mockMvc.perform(get("/api/v1/friend"))
                 .andExpect(status().isOk())

--- a/src/test/java/com/meme/ala/domain/friend/controller/FriendControllerTest.java
+++ b/src/test/java/com/meme/ala/domain/friend/controller/FriendControllerTest.java
@@ -3,8 +3,10 @@ package com.meme.ala.domain.friend.controller;
 import com.meme.ala.common.AbstractControllerTest;
 import com.meme.ala.common.EntityFactory;
 import com.meme.ala.core.config.AlaWithAccount;
+import com.meme.ala.domain.friend.model.entity.FriendRelation;
 import com.meme.ala.domain.member.model.entity.Member;
 import com.meme.ala.domain.friend.service.FriendInfoService;
+import com.meme.ala.domain.member.service.MemberService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -29,7 +31,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class FriendControllerTest extends AbstractControllerTest {
 
     @MockBean
-    private FriendInfoService memberFriendInfoService;
+    private FriendInfoService friendInfoService;
+
+    @MockBean
+    private MemberService memberService;
 
     @AlaWithAccount("test@gmail.com")
     @Test
@@ -37,7 +42,8 @@ public class FriendControllerTest extends AbstractControllerTest {
 
         List<Member> friends = Arrays.asList(EntityFactory.testMember());
 
-        given(memberFriendInfoService.getMemberFriend(any(Member.class))).willReturn(friends);
+        given(memberService.findByNickname(any(String.class))).willReturn(EntityFactory.testMember());
+        given(friendInfoService.getMemberFriend(any(Member.class))).willReturn(friends);
 
         mockMvc.perform(get("/api/v1/friend"))
                 .andExpect(status().isOk())
@@ -60,7 +66,38 @@ public class FriendControllerTest extends AbstractControllerTest {
 
     @AlaWithAccount("test@gmail.com")
     @Test
+    public void 사용자와_상대방_관계_조회() throws Exception{
+
+        given(memberService.findByNickname(any(String.class))).willReturn(EntityFactory.testMember());
+        given(friendInfoService.getRelation(any(Member.class), any(Member.class))).willReturn(FriendRelation.FRIEND);
+
+        mockMvc.perform(get("/api/v1/friend/relation/{nickname}", "testNickname"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value(READ_MEMBER_AND_PERSON_RELATION))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.nickname").value("testNickname"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.relation").value(FriendRelation.FRIEND.getKrRelation()))
+                .andDo(print())
+                .andDo(document("api/v1/friend/relation/nickname",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("nickname").description("친구 닉네임")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("응답 상태"),
+                                fieldWithPath("message").description("설명"),
+                                fieldWithPath("data.nickname").description("상대방 닉네임"),
+                                fieldWithPath("data.relation").description("상대방과의 관계(일반, 팔로잉, 팔로워, 친구)"),
+                                fieldWithPath("timestamp").description("타임스탬프")
+                        )
+                ));
+    }
+
+    @AlaWithAccount("test@gmail.com")
+    @Test
     public void 사용자_친구_추가_테스트() throws Exception{
+
+        given(memberService.findByNickname(any(String.class))).willReturn(EntityFactory.testMember());
 
         mockMvc.perform(post("/api/v1/friend/{nickname}", "testNickname"))
                 .andExpect(status().isOk())
@@ -78,6 +115,8 @@ public class FriendControllerTest extends AbstractControllerTest {
     @AlaWithAccount("test@gmail.com")
     @Test
     public void 사용자_친구_수락_테스트() throws Exception{
+
+        given(memberService.findByNickname(any(String.class))).willReturn(EntityFactory.testMember());
 
         mockMvc.perform(post("/api/v1/friend/accept/{nickname}", "testNickname"))
                 .andExpect(status().isOk())

--- a/src/test/java/com/meme/ala/domain/friend/service/FriendInfoServiceTest.java
+++ b/src/test/java/com/meme/ala/domain/friend/service/FriendInfoServiceTest.java
@@ -11,6 +11,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import java.util.LinkedList;
 import java.util.Optional;
@@ -19,21 +22,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
-
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest
 class FriendInfoServiceTest {
 
-    @InjectMocks
-    private FriendInfoServiceImpl friendService;
+    @Autowired
+    private FriendInfoService friendInfoService;
 
-    @Mock
+    @MockBean
     private FriendInfoRepository friendInfoRepository;
 
-    @Mock
+    @MockBean
     private MemberRepository memberRepository;
 
     @Test
-    void addMemberFriend() {
+    void followFriend() {
         Member member = EntityFactory.testMember(); // objectId : 60f3f89c9f21ff292724eb38
 
         FriendInfo memberFriendInfo = EntityFactory.testFriendInfo();
@@ -51,7 +53,7 @@ class FriendInfoServiceTest {
         given(friendInfoRepository.findById(eq(following.getId()))).willReturn(Optional.of(followingFriendInfo));
         given(friendInfoRepository.findById(eq(member.getId()))).willReturn(Optional.of(memberFriendInfo));
 
-        friendService.followingFriend(member, "friendNickname");
+        friendInfoService.followingFriend(member, following);
 
         assertEquals(followingFriendInfo.getMyAcceptancePendingList().size(), 3);
         assertEquals(followingFriendInfo.getMyAcceptancePendingList().get(2), member.getId());
@@ -77,7 +79,7 @@ class FriendInfoServiceTest {
         given(friendInfoRepository.findById(eq(member.getId()))).willReturn(Optional.of(memberFriendInfo));
         given(friendInfoRepository.findById(eq(follower.getId()))).willReturn(Optional.of(followerFriendInfo));
 
-        friendService.acceptFollowerToFriend(member, "testNickname");
+        friendInfoService.acceptFollowerToFriend(member, follower);
 
         assertEquals(memberFriendInfo.getMyAcceptancePendingList().size(), 2);
         assertEquals(memberFriendInfo.getFriends().size(), 3);

--- a/src/test/java/com/meme/ala/domain/friend/service/FriendInfoServiceTest.java
+++ b/src/test/java/com/meme/ala/domain/friend/service/FriendInfoServiceTest.java
@@ -1,8 +1,6 @@
 package com.meme.ala.domain.friend.service;
 
 import com.meme.ala.common.EntityFactory;
-import com.meme.ala.core.error.ErrorCode;
-import com.meme.ala.core.error.exception.EntityNotFoundException;
 import com.meme.ala.domain.friend.model.entity.FriendInfo;
 import com.meme.ala.domain.friend.repository.FriendInfoRepository;
 import com.meme.ala.domain.member.model.entity.Member;
@@ -14,7 +12,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.Optional;
 
@@ -24,10 +21,10 @@ import static org.mockito.BDDMockito.given;
 
 
 @ExtendWith(MockitoExtension.class)
-class FriendServiceTest {
+class FriendInfoServiceTest {
 
     @InjectMocks
-    private FriendServiceImpl friendService;
+    private FriendInfoServiceImpl friendService;
 
     @Mock
     private FriendInfoRepository friendInfoRepository;
@@ -42,7 +39,7 @@ class FriendServiceTest {
         FriendInfo memberFriendInfo = EntityFactory.testFriendInfo();
         memberFriendInfo.setMemberId(member.getId());
         memberFriendInfo.setFriends(new LinkedList<>());
-        memberFriendInfo.setPendings(new LinkedList<>());
+        memberFriendInfo.setMyAcceptancePendingList(new LinkedList<>());
 
         Member following = EntityFactory.testMember(); // // objectId : 000000000000000000000001
         following.setId(new ObjectId(EntityFactory.testObjectId() + "1"));
@@ -54,10 +51,10 @@ class FriendServiceTest {
         given(friendInfoRepository.findById(eq(following.getId()))).willReturn(Optional.of(followingFriendInfo));
         given(friendInfoRepository.findById(eq(member.getId()))).willReturn(Optional.of(memberFriendInfo));
 
-        friendService.addMemberFriend(member, "friendNickname");
+        friendService.followingFriend(member, "friendNickname");
 
-        assertEquals(followingFriendInfo.getPendings().size(), 3);
-        assertEquals(followingFriendInfo.getPendings().get(2), member.getId());
+        assertEquals(followingFriendInfo.getMyAcceptancePendingList().size(), 3);
+        assertEquals(followingFriendInfo.getMyAcceptancePendingList().get(2), member.getId());
     }
 
     @Test
@@ -69,20 +66,20 @@ class FriendServiceTest {
         Member follower = EntityFactory.testMember(); // objectId : 60f3f89c9f21ff292724eb38
 
         FriendInfo memberFriendInfo = EntityFactory.testFriendInfo();
-        memberFriendInfo.getPendings().add(follower.getId());
+        memberFriendInfo.getMyAcceptancePendingList().add(follower.getId());
 
         FriendInfo followerFriendInfo = EntityFactory.testFriendInfo();
         followerFriendInfo.setMemberId(follower.getId());
         followerFriendInfo.setFriends(new LinkedList<>());
-        followerFriendInfo.setPendings(new LinkedList<>());
+        followerFriendInfo.setMyAcceptancePendingList(new LinkedList<>());
 
         given(memberRepository.findByMemberSettingNickname(eq(follower.getMemberSetting().getNickname()))).willReturn(Optional.of(follower));
         given(friendInfoRepository.findById(eq(member.getId()))).willReturn(Optional.of(memberFriendInfo));
         given(friendInfoRepository.findById(eq(follower.getId()))).willReturn(Optional.of(followerFriendInfo));
 
-        friendService.acceptMemberFriend(member, "testNickname");
+        friendService.acceptFollowerToFriend(member, "testNickname");
 
-        assertEquals(memberFriendInfo.getPendings().size(), 2);
+        assertEquals(memberFriendInfo.getMyAcceptancePendingList().size(), 2);
         assertEquals(memberFriendInfo.getFriends().size(), 3);
         assertEquals(memberFriendInfo.getFriends().get(2), follower.getId());
 


### PR DESCRIPTION
- 친구 엔티티 변경
- 친구 서비스를 새로 만들어서 친구 정보 서비스에서 친구 서비스를 호출하는 식으로 layer 분리
  (컨트롤러 -> 친구 정보 서비스 -> (친구 서비스 : 친구 관계 설정) -> 친구 정보 서비스 -> 리포지토리)
- Enum 클래스 만들어서 친구정보 엔티티에서 상대방과의 친구 관계 파악하도록 함
- 상대방과의 친구 관계 조회 API 작성
  기존에 닉네임을 통해 멤버 엔티티를 친구 정보 서비스에서 얻어오던 것을 컨트롤러 계층으로 옮기고, 
  멤버 엔티티를 인자로 넘기도록 수정