### PR TITLE
Feat: 닉네임 알고리즘 수정

### DIFF
--- a/src/main/java/com/meme/ala/domain/member/model/entity/Member.java
+++ b/src/main/java/com/meme/ala/domain/member/model/entity/Member.java
@@ -9,6 +9,7 @@ import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.LocalDateTime;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -34,4 +35,7 @@ public class Member {
 
     @Builder.Default
     private List<AlaCardSettingPair> alaCardSettingPairList = new LinkedList<>();
+
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
 }

--- a/src/main/java/com/meme/ala/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/meme/ala/domain/member/repository/MemberRepository.java
@@ -20,4 +20,6 @@ public interface MemberRepository extends MongoRepository<Member, ObjectId> {
     boolean existsMemberByEmail(String email);
 
     Optional<Member> findById(ObjectId id);
+
+    Member findTop1ByMemberSettingNicknameRegexOrderByCreatedAtDesc(String regex);
 }

--- a/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
@@ -35,11 +35,17 @@ public class MemberServiceImpl implements MemberService {
     @PublishEvent
     @Transactional
     public String join(OAuthUserInfo authUserInfo, String provider) {
+        int newNumber = 0;
+        if (memberRepository.count() != 0) {
+            Member lastMember = memberRepository.findTop1ByMemberSettingNicknameRegexOrderByCreatedAtDesc("ala_[0-9]+");
+            String lastNumber = lastMember.getMemberSetting().getNickname().split("_")[1];
+            newNumber = Integer.parseInt(lastNumber) + 1;
+        }
         Member newMember = Member.builder()
                 .email(authUserInfo.getEmail())
                 .memberSetting(
                         MemberSetting.builder()
-                                .nickname("ala_" + memberRepository.count())
+                                .nickname("ala_" + newNumber)
                                 .build())
                 .build();
         if (provider.equals(OAuthProvider.GOOGLE)) {


### PR DESCRIPTION
- Member 클래스에 createdAt 필드 추가(default로 join시 시간할당)
- Dto에서 createdAt을 쓰지 않고, join이외의 서비스 로직에서 createdAt으로 인한 변동이 없으므로 사이드이펙트 없음(모든 테스트 통과)

- findTop1ByMemberSettingNicknameRegexOrderByCreatedAtDesc 로 가장 마지막 ala_숫자 닉네임을 가진 사람 뽑기
메소드 뜻: MemberSetting의 Nickname중에 파라미터로 주어진 정규표현식에 해당하는 사람들을 createdAt으로 내림차순 정렬하여 앞에서 한명 뽑아라.

- 왜 Order by MemberNickname으로 안했는지? : 문자열의 경우 ala_1, ala_10, ala_2, ala_3 의 순서로 정렬되는 문제가 발생하므로 createdAt으로 해야 함.