### PR TITLE
Feature 144/alacard setting background

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -178,6 +178,17 @@ include::{snippets}/api/v1/alacard/backgrounds/http-response.adoc[]
 .response fields
 include::{snippets}/api/v1/alacard/backgrounds/response-fields.adoc[]
 
+== GET /api/v1/alacard/background
+
+.request
+include::{snippets}/api/v1/alacard/background/http-request.adoc[]
+
+.response
+include::{snippets}/api/v1/alacard/background/http-response.adoc[]
+
+.response fields
+include::{snippets}/api/v1/alacard/background/response-fields.adoc[]
+
 == PATCH /api/v1/alacard/alacardsetting
 
 .request

--- a/src/main/java/com/meme/ala/domain/alacard/controller/AlaCardController.java
+++ b/src/main/java/com/meme/ala/domain/alacard/controller/AlaCardController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletResponse;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RequestMapping(value = "/api/v1/alacard")
@@ -90,6 +91,12 @@ public class AlaCardController {
     public ResponseEntity<ResponseDto<List<String>>> backgrounds() throws Exception {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.SUCCESS, alaCardService.getBackgroundImageUrls()));
+    }
+
+    @GetMapping("/background")
+    public ResponseEntity<ResponseDto<Map<String, List<String>>>> background() {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.SUCCESS, alaCardService.getBackgroundCategory()));
     }
 
     @PostMapping("/background")

--- a/src/main/java/com/meme/ala/domain/alacard/model/dto/response/AlaCardSettingDto.java
+++ b/src/main/java/com/meme/ala/domain/alacard/model/dto/response/AlaCardSettingDto.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-import org.bson.types.ObjectId;
 
 @Getter
 @Setter
@@ -14,6 +13,5 @@ public class AlaCardSettingDto {
     private String alaCardId;
     private String backgroundImgUrl;
     private String fontColor;
-    private String category;
     private Boolean isOpen;
 }

--- a/src/main/java/com/meme/ala/domain/alacard/model/entity/cardSetting/AlaCardSetting.java
+++ b/src/main/java/com/meme/ala/domain/alacard/model/entity/cardSetting/AlaCardSetting.java
@@ -3,12 +3,12 @@ package com.meme.ala.domain.alacard.model.entity.cardSetting;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.DBRef;
-import org.springframework.data.mongodb.core.mapping.Document;
 
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 public class AlaCardSetting {

--- a/src/main/java/com/meme/ala/domain/alacard/model/entity/cardSetting/Background.java
+++ b/src/main/java/com/meme/ala/domain/alacard/model/entity/cardSetting/Background.java
@@ -1,9 +1,6 @@
 package com.meme.ala.domain.alacard.model.entity.cardSetting;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -12,6 +9,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Setter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 @Document("BACKGROUND")
 public class Background {
     @Id

--- a/src/main/java/com/meme/ala/domain/alacard/model/mapper/AlaCardSettingMapper.java
+++ b/src/main/java/com/meme/ala/domain/alacard/model/mapper/AlaCardSettingMapper.java
@@ -2,22 +2,21 @@ package com.meme.ala.domain.alacard.model.mapper;
 
 import com.meme.ala.domain.alacard.model.dto.response.AlaCardSettingDto;
 import com.meme.ala.domain.alacard.model.entity.cardSetting.AlaCardSetting;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.ReportingPolicy;
+import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE, nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface AlaCardSettingMapper {
     AlaCardSettingMapper INSTANCE = Mappers.getMapper(AlaCardSettingMapper.class);
 
     @Mapping(target = "backgroundImgUrl", source = "background.imgUrl")
     @Mapping(target = "fontColor", source = "background.fontColor")
-    @Mapping(target = "category", source = "background.category")
     AlaCardSettingDto toDto(AlaCardSetting alaCardSetting);
 
     @Mapping(target = "background.imgUrl", source = "backgroundImgUrl")
     @Mapping(target = "background.fontColor", source = "fontColor")
-    @Mapping(target = "background.category", source = "category")
     AlaCardSetting toEntity(AlaCardSettingDto alaCardSettingDto);
+
+    @InheritConfiguration
+    void updateAlaCardSettingFromDto(AlaCardSettingDto alaCardSettingDto, @MappingTarget AlaCardSetting alaCardSetting);
 }

--- a/src/main/java/com/meme/ala/domain/alacard/repository/BackgroundRepository.java
+++ b/src/main/java/com/meme/ala/domain/alacard/repository/BackgroundRepository.java
@@ -3,11 +3,11 @@ package com.meme.ala.domain.alacard.repository;
 import com.meme.ala.domain.alacard.model.entity.cardSetting.Background;
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
+@Repository
 public interface BackgroundRepository extends MongoRepository<Background, ObjectId> {
     List<Background> findAll();
-    Optional<Background> findByImgUrl(String imgUrl);
 }

--- a/src/main/java/com/meme/ala/domain/alacard/repository/BackgroundRepository.java
+++ b/src/main/java/com/meme/ala/domain/alacard/repository/BackgroundRepository.java
@@ -5,7 +5,9 @@ import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BackgroundRepository extends MongoRepository<Background, ObjectId> {
     List<Background> findAll();
+    Optional<Background> findByImgUrl(String imgUrl);
 }

--- a/src/main/java/com/meme/ala/domain/alacard/service/AlaCardService.java
+++ b/src/main/java/com/meme/ala/domain/alacard/service/AlaCardService.java
@@ -8,6 +8,7 @@ import com.meme.ala.domain.alacard.model.entity.cardSetting.Background;
 import com.meme.ala.domain.member.model.entity.Member;
 
 import java.util.List;
+import java.util.Map;
 
 public interface AlaCardService {
     void save(AlaCard alaCard);
@@ -21,4 +22,6 @@ public interface AlaCardService {
     void saveBackground(BackgroundDto backgroundDto);
 
     List<Background> getBackgrounds();
+
+    Map<String,List<String>> getBackgroundCategory();
 }

--- a/src/main/java/com/meme/ala/domain/alacard/service/AlaCardServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/alacard/service/AlaCardServiceImpl.java
@@ -20,9 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -135,6 +133,25 @@ public class AlaCardServiceImpl implements AlaCardService {
     @Transactional(readOnly = true)
     public List<Background> getBackgrounds() {
         return backgroundRepository.findAll();
+    }
+
+    @Override
+    public Map<String, List<String>> getBackgroundCategory() {
+        Map<String, List<String>> backgroundMap = new HashMap<>();
+        List<Background> backgrounds = backgroundRepository.findAll();
+
+        for (Background background : backgrounds) {
+            String key = background.getCategory();
+            String value = background.getImgUrl();
+            if (backgroundMap.containsKey(key)) {
+                backgroundMap.get(key).add(value);
+            } else {
+                List<String> newList = new ArrayList<>();
+                newList.add(value);
+                backgroundMap.put(key, newList);
+            }
+        }
+        return backgroundMap;
     }
 
     private List<WordCount> toSortedWordCountList(Aggregation aggregation, String middleCategoryName) {

--- a/src/main/java/com/meme/ala/domain/member/service/MemberCardServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberCardServiceImpl.java
@@ -10,6 +10,7 @@ import com.meme.ala.domain.alacard.model.entity.cardSetting.AlaCardSetting;
 import com.meme.ala.domain.alacard.model.mapper.AlaCardSaveMapper;
 import com.meme.ala.domain.alacard.model.mapper.AlaCardSettingMapper;
 import com.meme.ala.domain.alacard.repository.AlaCardRepository;
+import com.meme.ala.domain.alacard.repository.BackgroundRepository;
 import com.meme.ala.domain.alacard.repository.TemporalWordListRepository;
 import com.meme.ala.domain.alacard.service.AlaCardService;
 import com.meme.ala.domain.member.model.entity.AlaCardSettingPair;
@@ -33,7 +34,7 @@ public class MemberCardServiceImpl implements MemberCardService {
     private final MemberRepository memberRepository;
     private final AlaCardRepository alaCardRepository;
     private final TemporalWordListRepository temporalWordListRepository;
-
+    private final BackgroundRepository backgroundRepository;
     private final MemberService memberService;
     private final AlaCardService alaCardService;
 

--- a/src/main/java/com/meme/ala/domain/member/service/MemberCardServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberCardServiceImpl.java
@@ -10,7 +10,6 @@ import com.meme.ala.domain.alacard.model.entity.cardSetting.AlaCardSetting;
 import com.meme.ala.domain.alacard.model.mapper.AlaCardSaveMapper;
 import com.meme.ala.domain.alacard.model.mapper.AlaCardSettingMapper;
 import com.meme.ala.domain.alacard.repository.AlaCardRepository;
-import com.meme.ala.domain.alacard.repository.BackgroundRepository;
 import com.meme.ala.domain.alacard.repository.TemporalWordListRepository;
 import com.meme.ala.domain.alacard.service.AlaCardService;
 import com.meme.ala.domain.member.model.entity.AlaCardSettingPair;
@@ -34,7 +33,6 @@ public class MemberCardServiceImpl implements MemberCardService {
     private final MemberRepository memberRepository;
     private final AlaCardRepository alaCardRepository;
     private final TemporalWordListRepository temporalWordListRepository;
-    private final BackgroundRepository backgroundRepository;
     private final MemberService memberService;
     private final AlaCardService alaCardService;
 
@@ -108,7 +106,7 @@ public class MemberCardServiceImpl implements MemberCardService {
         for (AlaCardSettingPair alaCardSettingPair : member.getAlaCardSettingPairList()) {
             if (alaCardSettingPair.getAlaCard().getId().toHexString()
                     .equals(alaCardSettingDto.getAlaCardId())) {
-                alaCardSettingPair.setAlaCardSetting(alaCardSettingMapper.toEntity(alaCardSettingDto));
+                alaCardSettingMapper.updateAlaCardSettingFromDto(alaCardSettingDto, alaCardSettingPair.getAlaCardSetting());
                 break;
             }
         }

--- a/src/test/java/com/meme/ala/common/DtoFactory.java
+++ b/src/test/java/com/meme/ala/common/DtoFactory.java
@@ -79,7 +79,6 @@ public class DtoFactory {
     public static AlaCardSettingDto testAlaCardSettingDto() {
         return AlaCardSettingDto.builder()
                 .backgroundImgUrl("http://test/background.jpg")
-                .category("solid")
                 .fontColor("#FFFFFF")
                 .isOpen(true)
                 .build();

--- a/src/test/java/com/meme/ala/domain/alacard/controller/AlaCardControllerTest.java
+++ b/src/test/java/com/meme/ala/domain/alacard/controller/AlaCardControllerTest.java
@@ -20,9 +20,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import static com.meme.ala.core.config.ApiDocumentUtils.getDocumentRequest;
 import static com.meme.ala.core.config.ApiDocumentUtils.getDocumentResponse;
@@ -183,6 +181,35 @@ public class AlaCardControllerTest extends AbstractControllerTest {
                                 fieldWithPath("status").description("응답 상태"),
                                 fieldWithPath("message").description("설명"),
                                 fieldWithPath("data").description("배경의 URL"),
+                                fieldWithPath("timestamp").description("타임스탬프")
+                        )
+                ));
+    }
+
+    @DisplayName("배경 리스트와 카테고리를 제공하는 테스트")
+    @Test
+    public void 배경_리스트와_카테고리를_제공하는_테스트() throws Exception {
+        Map<String, List<String>> sampleMap = new HashMap<>();
+        sampleMap.put("Gradient", Arrays.asList(s3Url + "/static/test.svg", s3Url + "/static/test2.svg", s3Url + "/static/test.svg", s3Url + "/static/test3.svg"));
+        sampleMap.put("Photo", Arrays.asList(s3Url + "/static/test4.svg", s3Url + "/static/test5.svg", s3Url + "/static/test6.svg", s3Url + "/static/test7.svg"));
+        sampleMap.put("Solid", Arrays.asList());
+
+        given(alaCardService.getBackgroundCategory()).willReturn(sampleMap);
+
+        mockMvc.perform(get("/api/v1/alacard/background"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.Gradient[0]").value(s3Url + "/static/test.svg"))
+                .andDo(print())
+                .andDo(document("api/v1/alacard/background",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        responseFields(
+                                fieldWithPath("status").description("응답 상태"),
+                                fieldWithPath("message").description("설명"),
+                                fieldWithPath("data").description("배경들"),
+                                fieldWithPath("data.Gradient").description("Gradient URL들"),
+                                fieldWithPath("data.Photo").description("Photo URL들"),
+                                fieldWithPath("data.Solid").description("Solid URL들"),
                                 fieldWithPath("timestamp").description("타임스탬프")
                         )
                 ));

--- a/src/test/java/com/meme/ala/domain/alacard/controller/AlaCardControllerTest.java
+++ b/src/test/java/com/meme/ala/domain/alacard/controller/AlaCardControllerTest.java
@@ -117,7 +117,6 @@ public class AlaCardControllerTest extends AbstractControllerTest {
                                 fieldWithPath("data[*].alaCardSettingDto.alaCardId").description("알라카드의 Id"),
                                 fieldWithPath("data[*].alaCardSettingDto.backgroundImgUrl").description("배경 이미지"),
                                 fieldWithPath("data[*].alaCardSettingDto.fontColor").description("글씨 색"),
-                                fieldWithPath("data[*].alaCardSettingDto.category").description("배경 카테고리"),
                                 fieldWithPath("data[*].alaCardSettingDto.isOpen").description("카드 공개 여부"),
                                 fieldWithPath("timestamp").description("타임스탬프")
                         )

--- a/src/test/java/com/meme/ala/domain/alacard/entity/mapper/AlaCardMapperTest.java
+++ b/src/test/java/com/meme/ala/domain/alacard/entity/mapper/AlaCardMapperTest.java
@@ -31,7 +31,6 @@ public class AlaCardMapperTest {
     void 엔티티에서_DTO변환_테스트() {
         AlaCardDto mappedDto = alaCardMapper.toDto(alaCard, alaCardSetting, "testSentence", wordCountList, true);
         assertEquals(mappedDto.getSelectedWordList().get(0).getWordName(), alaCardDto.getSelectedWordList().get(0).getWordName());
-        assertEquals(mappedDto.getAlaCardSettingDto().getCategory(), alaCardDto.getAlaCardSettingDto().getCategory());
         assertEquals(mappedDto.getAlaCardSettingDto().getFontColor(), alaCardDto.getAlaCardSettingDto().getFontColor());
         assertEquals(mappedDto.getAlaCardSettingDto().getBackgroundImgUrl(), alaCardDto.getAlaCardSettingDto().getBackgroundImgUrl());
     }

--- a/src/test/java/com/meme/ala/domain/alacard/entity/mapper/AlaCardSettingMapperTest.java
+++ b/src/test/java/com/meme/ala/domain/alacard/entity/mapper/AlaCardSettingMapperTest.java
@@ -3,8 +3,8 @@ package com.meme.ala.domain.alacard.entity.mapper;
 import com.meme.ala.common.DtoFactory;
 import com.meme.ala.common.EntityFactory;
 import com.meme.ala.domain.alacard.model.dto.response.AlaCardSettingDto;
-import com.meme.ala.domain.alacard.model.mapper.AlaCardSettingMapper;
 import com.meme.ala.domain.alacard.model.entity.cardSetting.AlaCardSetting;
+import com.meme.ala.domain.alacard.model.mapper.AlaCardSettingMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,8 +23,24 @@ public class AlaCardSettingMapperTest {
     void 엔티티에서_DTO변환_테스트() {
         AlaCardSettingDto mappedDto = alaCardSettingMapper.toDto(alaCardSetting);
         assertEquals(mappedDto.getBackgroundImgUrl(), alaCardSettingDto.getBackgroundImgUrl());
-        assertEquals(mappedDto.getCategory(), alaCardSettingDto.getCategory());
         assertEquals(mappedDto.getFontColor(), alaCardSettingDto.getFontColor());
         assertEquals(mappedDto.getIsOpen(), alaCardSettingDto.getIsOpen());
+    }
+
+    @Test
+    void 알라카드세팅_업데이트_테스트(){
+        AlaCardSetting updatedEntity = EntityFactory.testAlaCardSetting();
+        AlaCardSetting compareEntity = EntityFactory.testAlaCardSetting();
+        AlaCardSettingDto updateDto = DtoFactory.testAlaCardSettingDto();
+
+        updateDto.setBackgroundImgUrl("newtest.png");
+        updateDto.setFontColor(null);
+        updateDto.setIsOpen(null);
+
+        alaCardSettingMapper.updateAlaCardSettingFromDto(updateDto, updatedEntity);
+
+        assertEquals(updatedEntity.getBackground().getImgUrl(), "newtest.png");
+        assertEquals(updatedEntity.getBackground().getFontColor(), compareEntity.getBackground().getFontColor());
+        assertEquals(updatedEntity.getIsOpen(), compareEntity.getIsOpen());
     }
 }


### PR DESCRIPTION
Feat: Background 카테고리별로 분류해서 제공
기존의 /backgrounds api 유지하면서
/background  api 추가 제공함. 향후 프론트에서 로직 수정 완료되면 /backgorunds api 제거 예정

Feat: AlaCardSettingDto에서 Background의 Category 제공할/받을 필요없음
- Dto에서 Category 없앰
- updateDto 추가