### PR TITLE
Feature 124/quit member

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -106,13 +106,10 @@ include::{snippets}/api/v1/member/exists/http-response.adoc[]
 .response fields
 include::{snippets}/api/v1/member/exists/response-fields.adoc[]
 
-== GET /api/v1/member/delete
+== DELETE /api/v1/member
 
 .request
 include::{snippets}/api/v1/member/delete/http-request.adoc[]
-
-.request parameters
-include::{snippets}/api/v1/member/delete/request-parameters.adoc[]
 
 .response
 include::{snippets}/api/v1/member/delete/http-response.adoc[]

--- a/src/main/java/com/meme/ala/core/aop/PublishEventAspect.java
+++ b/src/main/java/com/meme/ala/core/aop/PublishEventAspect.java
@@ -1,7 +1,9 @@
 package com.meme.ala.core.aop;
 
+import com.meme.ala.domain.event.model.entity.DeleteEvent;
 import com.meme.ala.domain.event.model.entity.InitEvent;
 import com.meme.ala.domain.event.model.entity.SubmitEvent;
+import com.meme.ala.domain.member.model.entity.Member;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
@@ -31,6 +33,10 @@ public class PublishEventAspect implements ApplicationEventPublisherAware {
         }
         else if(method.equals("submitWordList")){
             SubmitEvent event = new SubmitEvent();
+            eventPublisher.publishEvent(event);
+        }
+        else if(method.equals("deleteMember")){
+            DeleteEvent event = new DeleteEvent((Member) returnObj);
             eventPublisher.publishEvent(event);
         }
     }

--- a/src/main/java/com/meme/ala/core/auth/jwt/UserDetailServiceImpl.java
+++ b/src/main/java/com/meme/ala/core/auth/jwt/UserDetailServiceImpl.java
@@ -16,6 +16,6 @@ public class UserDetailServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return new UserDetailsImpl(memberRepository.findByEmail(username).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND)));
+        return new UserDetailsImpl(memberRepository.findByEmailAndMemberSetting_IsDeleted(username, false).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND)));
     }
 }

--- a/src/main/java/com/meme/ala/domain/event/component/EventHandler.java
+++ b/src/main/java/com/meme/ala/domain/event/component/EventHandler.java
@@ -32,7 +32,7 @@ public class EventHandler {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void initMember(InitEvent event) {
-        Member member = memberRepository.findByEmail(event.getEmail())
+        Member member = memberRepository.findByEmailAndMemberSetting_IsDeleted(event.getEmail(), false)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
         memberCardService.assignCard(member, defaultCardNum);
         aggregationService.initAggregation(member);

--- a/src/main/java/com/meme/ala/domain/event/component/EventHandler.java
+++ b/src/main/java/com/meme/ala/domain/event/component/EventHandler.java
@@ -5,12 +5,15 @@ import com.meme.ala.core.error.exception.EntityNotFoundException;
 import com.meme.ala.domain.aggregation.model.entity.UserCount;
 import com.meme.ala.domain.aggregation.repository.UserCountRepository;
 import com.meme.ala.domain.aggregation.service.AggregationService;
+import com.meme.ala.domain.event.model.entity.DeleteEvent;
 import com.meme.ala.domain.event.model.entity.InitEvent;
 import com.meme.ala.domain.event.model.entity.SubmitEvent;
+import com.meme.ala.domain.friend.model.entity.FriendInfo;
 import com.meme.ala.domain.friend.service.FriendInfoService;
 import com.meme.ala.domain.member.model.entity.Member;
 import com.meme.ala.domain.member.repository.MemberRepository;
 import com.meme.ala.domain.member.service.MemberCardService;
+import com.meme.ala.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
@@ -28,6 +31,7 @@ public class EventHandler {
     private final MemberCardService memberCardService;
     private final MemberRepository memberRepository;
     private final UserCountRepository userCountRepository;
+    private final MemberService memberService;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -49,5 +53,17 @@ public class EventHandler {
             userCount.setCount(userCount.getCount() + 1);
             userCountRepository.save(userCount);
         }
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void deleteMember(DeleteEvent event) {
+        Member deletedMember = event.getDeletedMember();
+        /**
+         * Todo
+         * 삭제 관련 로직 처리
+         * 1.친구관계
+         */
+
     }
 }

--- a/src/main/java/com/meme/ala/domain/event/model/entity/DeleteEvent.java
+++ b/src/main/java/com/meme/ala/domain/event/model/entity/DeleteEvent.java
@@ -1,0 +1,11 @@
+package com.meme.ala.domain.event.model.entity;
+
+import com.meme.ala.domain.member.model.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DeleteEvent {
+    private Member deletedMember;
+}

--- a/src/main/java/com/meme/ala/domain/friend/service/FriendInfoService.java
+++ b/src/main/java/com/meme/ala/domain/friend/service/FriendInfoService.java
@@ -1,5 +1,6 @@
 package com.meme.ala.domain.friend.service;
 
+import com.meme.ala.domain.friend.model.entity.FriendInfo;
 import com.meme.ala.domain.friend.model.entity.FriendRelation;
 import com.meme.ala.domain.member.model.entity.Member;
 
@@ -15,4 +16,5 @@ public interface FriendInfoService {
     void unFriend(Member member, Member friend);
     void initFriendInfo(Member member);
     FriendRelation getRelation(Member member, Member person);
+    FriendInfo getFriendInfo(Member member);
 }

--- a/src/main/java/com/meme/ala/domain/member/controller/MemberController.java
+++ b/src/main/java/com/meme/ala/domain/member/controller/MemberController.java
@@ -46,9 +46,15 @@ public class MemberController {
                 .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.SUCCESS, memberService.existsNickname(nickname)));
     }
 
-    @GetMapping("/delete")
-    public ResponseEntity<ResponseDto<String>> deleteMemberByNickname(@RequestParam String nickname) {
-        memberService.deleteMemberByNickname(nickname);
+    /**
+     * TODO: Member 관련 API 전부 변경이 필요함 -> isActive 체크
+     * 1. 친구관계
+     * 2. 카드 선택
+     * 3. 사용자의 정보를 가져올 때?
+     */
+    @DeleteMapping()
+    public ResponseEntity<ResponseDto<String>> deleteMemberByNickname(@CurrentUser Member member) {
+        memberService.deleteMemberByNickname(member.getMemberSetting().getNickname());
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.SUCCESS, ResponseMessage.DELETED));
     }

--- a/src/main/java/com/meme/ala/domain/member/controller/MemberController.java
+++ b/src/main/java/com/meme/ala/domain/member/controller/MemberController.java
@@ -52,9 +52,9 @@ public class MemberController {
      * 2. 카드 선택
      * 3. 사용자의 정보를 가져올 때?
      */
-    @DeleteMapping()
+    @DeleteMapping
     public ResponseEntity<ResponseDto<String>> deleteMemberByNickname(@CurrentUser Member member) {
-        memberService.deleteMemberByNickname(member.getMemberSetting().getNickname());
+        memberService.deleteMember(member);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.SUCCESS, ResponseMessage.DELETED));
     }

--- a/src/main/java/com/meme/ala/domain/member/controller/MemberController.java
+++ b/src/main/java/com/meme/ala/domain/member/controller/MemberController.java
@@ -46,12 +46,6 @@ public class MemberController {
                 .body(ResponseDto.of(HttpStatus.OK, ResponseMessage.SUCCESS, memberService.existsNickname(nickname)));
     }
 
-    /**
-     * TODO: Member 관련 API 전부 변경이 필요함 -> isActive 체크
-     * 1. 친구관계
-     * 2. 카드 선택
-     * 3. 사용자의 정보를 가져올 때?
-     */
     @DeleteMapping
     public ResponseEntity<ResponseDto<String>> deleteMemberByNickname(@CurrentUser Member member) {
         memberService.deleteMember(member);

--- a/src/main/java/com/meme/ala/domain/member/model/entity/MemberSetting.java
+++ b/src/main/java/com/meme/ala/domain/member/model/entity/MemberSetting.java
@@ -25,5 +25,5 @@ public class MemberSetting {
     private Boolean isOpen = true;
 
     @Builder.Default
-    private Boolean isDeleted = true;
+    private Boolean isDeleted = false;
 }

--- a/src/main/java/com/meme/ala/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/meme/ala/domain/member/repository/MemberRepository.java
@@ -9,17 +9,17 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends MongoRepository<Member, ObjectId> {
-    Optional<Member> findByEmail(String email);
+    Optional<Member> findByEmailAndMemberSetting_IsDeleted(String email, boolean flag);
 
-    boolean existsMemberByMemberSettingNickname(String nickname);
+    boolean existsMemberByMemberSettingNicknameAndMemberSetting_IsDeleted(String nickname, boolean flag);
 
-    Optional<Member> findByMemberSettingNickname(String nickname);
+    Optional<Member> findByMemberSettingNicknameAndMemberSetting_IsDeleted(String nickname, boolean flag);
 
     void deleteMemberByMemberSettingNickname(String nickname);
 
-    boolean existsMemberByEmail(String email);
+    boolean existsMemberByEmailAndMemberSetting_IsDeleted(String email, boolean flag);
 
-    Optional<Member> findById(ObjectId id);
+    Optional<Member> findByIdAndMemberSetting_IsDeleted(ObjectId id, boolean flag);
 
     Member findTop1ByMemberSettingNicknameRegexOrderByCreatedAtDesc(String regex);
 }

--- a/src/main/java/com/meme/ala/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/meme/ala/domain/member/repository/MemberRepository.java
@@ -15,8 +15,6 @@ public interface MemberRepository extends MongoRepository<Member, ObjectId> {
 
     Optional<Member> findByMemberSettingNicknameAndMemberSetting_IsDeleted(String nickname, boolean flag);
 
-    void deleteMemberByMemberSettingNickname(String nickname);
-
     boolean existsMemberByEmailAndMemberSetting_IsDeleted(String email, boolean flag);
 
     Optional<Member> findByIdAndMemberSetting_IsDeleted(ObjectId id, boolean flag);

--- a/src/main/java/com/meme/ala/domain/member/service/MemberService.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberService.java
@@ -19,7 +19,7 @@ public interface MemberService {
 
     Member findByMemberId(ObjectId memberId);
 
-    void deleteMember(Member member);
+    Member deleteMember(Member member);
 
     String shareSelectLink(String nickname);
 

--- a/src/main/java/com/meme/ala/domain/member/service/MemberService.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberService.java
@@ -19,7 +19,7 @@ public interface MemberService {
 
     Member findByMemberId(ObjectId memberId);
 
-    void deleteMemberByNickname(String nickname);
+    void deleteMember(Member member);
 
     String shareSelectLink(String nickname);
 

--- a/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
@@ -85,8 +85,9 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     @Transactional
-    public void deleteMemberByNickname(String nickname) {
-        memberRepository.deleteMemberByMemberSettingNickname(nickname);
+    public void deleteMember(Member member) {
+        member.getMemberSetting().setIsDeleted(true);
+        memberRepository.save(member);
     }
 
     @Override

--- a/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
@@ -28,7 +28,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional(readOnly = true)
     public boolean existsEmail(String email) {
-        return memberRepository.existsMemberByEmail(email);
+        return memberRepository.existsMemberByEmailAndMemberSetting_IsDeleted(email, false);
     }
 
     @Override
@@ -69,18 +69,18 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional(readOnly = true)
     public boolean existsNickname(String nickname) {
-        return memberRepository.existsMemberByMemberSettingNickname(nickname);
+        return memberRepository.existsMemberByMemberSettingNicknameAndMemberSetting_IsDeleted(nickname, false);
     }
 
     @Override
     @Transactional(readOnly = true)
     public Member findByNickname(String nickname) {
-        return memberRepository.findByMemberSettingNickname(nickname).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+        return memberRepository.findByMemberSettingNicknameAndMemberSetting_IsDeleted(nickname, false).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
     }
 
     @Override
     public Member findByMemberId(ObjectId memberId) {
-        return memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+        return memberRepository.findByIdAndMemberSetting_IsDeleted(memberId, false).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/member/service/MemberServiceImpl.java
@@ -83,11 +83,14 @@ public class MemberServiceImpl implements MemberService {
         return memberRepository.findByIdAndMemberSetting_IsDeleted(memberId, false).orElseThrow(() -> new EntityNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
     }
 
+    @PublishEvent
     @Override
     @Transactional
-    public void deleteMember(Member member) {
+    public Member deleteMember(Member member) {
         member.getMemberSetting().setIsDeleted(true);
         memberRepository.save(member);
+
+        return member;
     }
 
     @Override

--- a/src/test/java/com/meme/ala/domain/friend/service/FriendInfoServiceTest.java
+++ b/src/test/java/com/meme/ala/domain/friend/service/FriendInfoServiceTest.java
@@ -7,10 +7,6 @@ import com.meme.ala.domain.member.model.entity.Member;
 import com.meme.ala.domain.member.repository.MemberRepository;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -49,7 +45,7 @@ class FriendInfoServiceTest {
 
         FriendInfo followingFriendInfo = EntityFactory.testFriendInfo();
 
-        given(memberRepository.findByMemberSettingNickname(eq(following.getMemberSetting().getNickname()))).willReturn(Optional.of(following));
+        given(memberRepository.findByMemberSettingNicknameAndMemberSetting_IsDeleted(eq(following.getMemberSetting().getNickname()), eq(false))).willReturn(Optional.of(following));
         given(friendInfoRepository.findById(eq(following.getId()))).willReturn(Optional.of(followingFriendInfo));
         given(friendInfoRepository.findById(eq(member.getId()))).willReturn(Optional.of(memberFriendInfo));
 
@@ -75,7 +71,7 @@ class FriendInfoServiceTest {
         followerFriendInfo.setFriends(new LinkedList<>());
         followerFriendInfo.setMyAcceptancePendingList(new LinkedList<>());
 
-        given(memberRepository.findByMemberSettingNickname(eq(follower.getMemberSetting().getNickname()))).willReturn(Optional.of(follower));
+        given(memberRepository.findByMemberSettingNicknameAndMemberSetting_IsDeleted(eq(follower.getMemberSetting().getNickname()), eq(false))).willReturn(Optional.of(follower));
         given(friendInfoRepository.findById(eq(member.getId()))).willReturn(Optional.of(memberFriendInfo));
         given(friendInfoRepository.findById(eq(follower.getId()))).willReturn(Optional.of(followerFriendInfo));
 

--- a/src/test/java/com/meme/ala/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/meme/ala/domain/member/controller/MemberControllerTest.java
@@ -5,6 +5,7 @@ import com.meme.ala.common.EntityFactory;
 import com.meme.ala.core.config.AlaWithAccount;
 import com.meme.ala.domain.member.model.entity.Member;
 import com.meme.ala.domain.member.repository.MemberRepository;
+import com.meme.ala.domain.member.service.MemberService;
 import org.junit.jupiter.api.*;
 import org.mockito.AdditionalAnswers;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,6 +31,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+// TODO: memberService를 MockBean으로 주입해야 함
 public class MemberControllerTest extends AbstractControllerTest {
     @MockBean
     private MemberRepository memberRepository;
@@ -160,22 +162,20 @@ public class MemberControllerTest extends AbstractControllerTest {
                         )
                 ));
     }
-
-    @DisplayName("사용자 닉네임으로 삭제 테스트")
+    
+    @AlaWithAccount("test")
+    @DisplayName("사용자 삭제 테스트")
     @Test
-    public void 사용자_닉네임_삭제_테스트() throws Exception{
-        doNothing().when(memberRepository).deleteMemberByMemberSettingNickname("testNickname");
+    public void 사용자_삭제_테스트() throws Exception{
+        given(memberRepository.save(any(Member.class))).willReturn(EntityFactory.testMember());
 
-        mockMvc.perform(get("/api/v1/member/delete?nickname=testNickname"))
+        mockMvc.perform(delete("/api/v1/member"))
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data").value("deleted"))
                 .andDo(print())
-                .andDo(document("api/v1/member/delete",
+                .andDo(document("api/v1/member",
                         getDocumentRequest(),
                         getDocumentResponse(),
-                        requestParameters(
-                                parameterWithName("nickname").description("닉네임")
-                        ),
                         responseFields(
                                 fieldWithPath("status").description("응답 상태"),
                                 fieldWithPath("message").description("설명"),

--- a/src/test/java/com/meme/ala/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/meme/ala/domain/member/controller/MemberControllerTest.java
@@ -18,6 +18,7 @@ import static com.meme.ala.core.config.ApiDocumentUtils.getDocumentRequest;
 import static com.meme.ala.core.config.ApiDocumentUtils.getDocumentResponse;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
@@ -65,7 +66,7 @@ public class MemberControllerTest extends AbstractControllerTest {
     @DisplayName("사용자 세팅 정보를 읽어오는 테스트")
     @Test
     public void 사용자_세팅_정보를_읽기_유닛테스트() throws Exception{
-        given(memberRepository.findByMemberSettingNickname(any(String.class))).willReturn(Optional.of(EntityFactory.testMember()));
+        given(memberRepository.findByMemberSettingNicknameAndMemberSetting_IsDeleted(any(String.class), eq(false))).willReturn(Optional.of(EntityFactory.testMember()));
 
         mockMvc.perform(get("/api/v1/member").param("nickname", "testNickname"))
                 .andExpect(status().isOk())
@@ -139,7 +140,7 @@ public class MemberControllerTest extends AbstractControllerTest {
     @DisplayName("사용자 닉네임 중복 처리 테스트")
     @Test
     public void 사용자_닉네임_중복_처리_테스트() throws Exception{
-        when(memberRepository.existsMemberByMemberSettingNickname("testNickname")).thenReturn(true);
+        when(memberRepository.existsMemberByMemberSettingNicknameAndMemberSetting_IsDeleted("testNickname", false)).thenReturn(true);
 
         mockMvc.perform(get("/api/v1/member/exists?nickname=testNickname"))
                 .andExpect(status().isOk())

--- a/src/test/java/com/meme/ala/domain/member/service/MemberCardServiceTest.java
+++ b/src/test/java/com/meme/ala/domain/member/service/MemberCardServiceTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
@@ -46,7 +47,7 @@ public class MemberCardServiceTest {
             alaCardList.add(alaCard);
         }
         when(memberRepository.save(any(Member.class))).then(AdditionalAnswers.returnsFirstArg());
-        when(memberRepository.existsMemberByMemberSettingNickname(any(String.class))).thenReturn(false);
+        when(memberRepository.existsMemberByMemberSettingNicknameAndMemberSetting_IsDeleted(any(String.class), eq(false))).thenReturn(false);
         when(alaCardRepository.findAll()).thenReturn(alaCardList);
         when(alaCardService.getBackgrounds()).thenReturn(Arrays.asList(EntityFactory.testAlaCardSetting().getBackground()));
 

--- a/src/test/java/com/meme/ala/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/meme/ala/domain/member/service/MemberServiceTest.java
@@ -25,7 +25,7 @@ public class MemberServiceTest {
         Member testMember= EntityFactory.testMember();
 
         given(memberRepository
-                .existsMemberByMemberSettingNickname(testMember.getMemberSetting().getNickname()))
+                .existsMemberByMemberSettingNicknameAndMemberSetting_IsDeleted(testMember.getMemberSetting().getNickname(),false))
                 .willReturn(true);
 
         assertThat(memberService.existsNickname(testMember.getMemberSetting().getNickname())).isTrue();


### PR DESCRIPTION
탈퇴한 친구 처리
- isDeleted의 default value가 true로 되어있어서 mongoDB 모든 값을 바꿔줘야 함
- 친구 관계를 처리할 때, 모든 친구 끊기를 해야할 지 고민 됨(지금은 try ~ catch로 패스하도록 처리)
