### PR TITLE
Feat: Aggregation 로직 수정

### DIFF
--- a/src/main/java/com/meme/ala/domain/aggregation/service/AggregationServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/aggregation/service/AggregationServiceImpl.java
@@ -11,6 +11,7 @@ import com.meme.ala.domain.aggregation.model.entity.WordCount;
 import com.meme.ala.domain.aggregation.repository.AggregationRepository;
 import com.meme.ala.domain.aggregation.repository.UserCountRepository;
 import com.meme.ala.domain.alacard.model.entity.MiddleCategory;
+import com.meme.ala.domain.alacard.model.entity.Word;
 import com.meme.ala.domain.member.model.entity.AlaCardSettingPair;
 import com.meme.ala.domain.member.model.entity.Member;
 import lombok.RequiredArgsConstructor;
@@ -86,21 +87,25 @@ public class AggregationServiceImpl implements AggregationService {
         List<WordCount> aggregationList = aggregation.getWordCountList();
         String middleCategory = submitWordEntry.getKey();
         List<String> wordNameList = submitWordEntry.getValue();
+        ObjectId cardId = null;
         for (int i = 0; i < aggregation.getWordCountList().size(); i++) {
             if (aggregationList.get(i).getMiddleCategoryName().equals(middleCategory)) {
+                cardId = aggregationList.get(i).getCardId();
                 if (wordNameList.contains(aggregationList.get(i).getWord().getWordName())) {
+                    String wordName = aggregationList.get(i).getWord().getWordName();
                     aggregationList.get(i).setCount(aggregationList.get(i).getCount() + 1);
-                } else {
-                    WordCount wordCount = WordCount.builder()
-                            .count(0)
-                            .word(aggregationList.get(i).getWord())
-                            .cardId(aggregationList.get(i).getCardId())
-                            .middleCategoryName(middleCategory)
-                            .build();
-                    aggregation.getWordCountList().add(wordCount);
-                    aggregationRepository.save(aggregation);
+                    wordNameList.removeIf(n -> n.equals(wordName));
                 }
             }
+        }
+        for (String wordName : wordNameList) {
+            WordCount wordCount = WordCount.builder()
+                    .count(0)
+                    .word(Word.builder().wordName(wordName).build())
+                    .cardId(cardId)
+                    .middleCategoryName(middleCategory)
+                    .build();
+            aggregation.getWordCountList().add(wordCount);
         }
     }
 

--- a/src/main/java/com/meme/ala/domain/aggregation/service/AggregationServiceImpl.java
+++ b/src/main/java/com/meme/ala/domain/aggregation/service/AggregationServiceImpl.java
@@ -77,17 +77,31 @@ public class AggregationServiceImpl implements AggregationService {
     public void submitWordList(Member member, Aggregation aggregation, List<String> wordIdList) throws UnsupportedEncodingException {
         Map<String, LinkedList<String>> dtoMap = dtoListToMapByMiddleCategory(wordIdList);
         for (Map.Entry<String, LinkedList<String>> entry : dtoMap.entrySet()) {
-            String middleCategory = entry.getKey();
-            List<String> wordNameList = entry.getValue();
-            List<WordCount> aggregationList = aggregation.getWordCountList();
-            for (int i = 0; i < aggregation.getWordCountList().size(); i++) {
-                if (aggregationList.get(i).getMiddleCategoryName().equals(middleCategory) &&
-                        wordNameList.contains(aggregationList.get(i).getWord().getWordName())) {
+            applyToAggregation(entry, aggregation);
+        }
+        aggregationRepository.save(aggregation);
+    }
+
+    private void applyToAggregation(Map.Entry<String, LinkedList<String>> submitWordEntry, Aggregation aggregation) {
+        List<WordCount> aggregationList = aggregation.getWordCountList();
+        String middleCategory = submitWordEntry.getKey();
+        List<String> wordNameList = submitWordEntry.getValue();
+        for (int i = 0; i < aggregation.getWordCountList().size(); i++) {
+            if (aggregationList.get(i).getMiddleCategoryName().equals(middleCategory)) {
+                if (wordNameList.contains(aggregationList.get(i).getWord().getWordName())) {
                     aggregationList.get(i).setCount(aggregationList.get(i).getCount() + 1);
+                } else {
+                    WordCount wordCount = WordCount.builder()
+                            .count(0)
+                            .word(aggregationList.get(i).getWord())
+                            .cardId(aggregationList.get(i).getCardId())
+                            .middleCategoryName(middleCategory)
+                            .build();
+                    aggregation.getWordCountList().add(wordCount);
+                    aggregationRepository.save(aggregation);
                 }
             }
         }
-        aggregationRepository.save(aggregation);
     }
 
     @Override


### PR DESCRIPTION
- 기존 submit wordlist에서 if(middlecategory가 일치 && word in aggregation) 로직을 수정
```
if(middleCategory가 일치){
    if(word in aggregation){
        기존 로직 수행
    }
    else{
        aggregation에 단어 추가해주는 로직 개발하기
    }
}
```

- 잠재적 문제점과 내 생각: 기존에 선정되었었던 단어가 있으면 그게 aggregation에서 사라지지 않아서 consistency?가 깨지는 문제가 발생할 수 있음
- 그런데 단어를 제출받는 폼에는 사라진 단어들이 등장하지 않으므로 긴 기간 후에는 결국 aggregation에서 선택받지 못해서 사라질 것. 

혹시 문제가 또 생긴다면,
aggregation에 단어 추가해주는 로직이 실행될 때(consistency가 깨진 상황) 비동기/동기로 aggregation과 사용자의 alacard를 대조해서 없는거를 aggregation에서 빼주는 로직도 추가 가능함
현재는 개발하지 않을 계획 